### PR TITLE
feat(sh): install_humioctl

### DIFF
--- a/.assets/provision/install_humioctl.sh
+++ b/.assets/provision/install_humioctl.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+: '
+sudo .assets/provision/install_humioctl.sh >/dev/null
+'
+set -euo pipefail
+
+if [ $EUID -ne 0 ]; then
+  printf '\e[31;1mRun the script as root.\e[0m\n' >&2
+  exit 1
+fi
+
+# dotsource file with common functions
+. .assets/provision/source.sh
+
+# define variables
+APP='humioctl'
+REL=${1:-}
+# get latest release if not provided as a parameter
+if [ -z "$REL" ]; then
+  REL="$(get_gh_release_latest --owner 'humio' --repo 'cli')"
+  if [ -z "$REL" ]; then
+    printf "\e[31mFailed to get the latest version of $APP.\e[0m\n" >&2
+    exit 1
+  fi
+fi
+# return the release
+echo $REL
+
+if type $APP &>/dev/null; then
+  VER=$($APP --version 2>&1 | sed -En 's/humioctl ([0-9\.]+) .*/\1/p')
+  if [ "$REL" = "$VER" ]; then
+    printf "\e[32m$APP v$VER is already latest\e[0m\n" >&2
+    exit 0
+  fi
+fi
+
+printf "\e[92minstalling \e[1m$APP\e[22m v$REL\e[0m\n" >&2
+# create temporary dir for the downloaded binary
+TMP_DIR=$(mktemp -d -p "$HOME")
+trap 'rm -fr "$TMP_DIR"' EXIT
+# calculate download uri
+URL="https://github.com/humio/cli/releases/download/v${REL}/humioctl_Linux_x86_64.tar.gz"
+# download and install file
+if download_file --uri "$URL" --target_dir "$TMP_DIR"; then
+  tar -zxf "$TMP_DIR/$(basename $URL)" -C "$TMP_DIR"
+  install -m 0755 "$TMP_DIR/humioctl" /usr/local/bin/
+fi

--- a/.assets/scripts/linux_setup.sh
+++ b/.assets/scripts/linux_setup.sh
@@ -181,6 +181,7 @@ for sc in "${scope_arr[@]}"; do
     sudo .assets/provision/install_flux.sh >/dev/null
     sudo .assets/provision/install_helm.sh >/dev/null
     sudo .assets/provision/install_hubble.sh >/dev/null
+    sudo .assets/provision/install_humioctl.sh >/dev/null
     sudo .assets/provision/install_kustomize.sh >/dev/null
     sudo .assets/provision/install_trivy.sh >/dev/null
     ;;

--- a/wsl/wsl_install.ps1
+++ b/wsl/wsl_install.ps1
@@ -23,7 +23,7 @@ List of installation scopes. Valid values:
 - docker: (WSL2 only) - docker, containerd buildx docker-compose
 - gcloud: google-cloud-cli
 - k8s_base: kubectl, kubelogin, k9s, kubecolor, kubectx, kubens
-- k8s_dev: argorollouts, cilium, hubble, helm, flux, kustomize and trivy cli tools; autoselects k8s_base scope
+- k8s_dev: argorollouts, cilium, hubble, helm, flux, humioctl, kustomize and trivy cli tools; autoselects k8s_base scope
 - k8s_ext: (WSL2 only) - minikube, k3d, kind local kubernetes tools; autoselects docker, k8s_base and k8s_dev scopes
 - nodejs: Node.js JavaScript runtime environment using V8 engine
 - pwsh: PowerShell Core and corresponding PS modules; autoselects shell scope

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -25,7 +25,7 @@ List of installation scopes. Valid values:
 - docker: (WSL2 only) - docker, containerd buildx docker-compose
 - gcloud: google-cloud-cli
 - k8s_base: kubectl, kubelogin, k9s, kubecolor, kubectx, kubens
-- k8s_dev: argorollouts, cilium, hubble, helm, flux, kustomize and trivy cli tools; autoselects k8s_base scope
+- k8s_dev: argorollouts, cilium, hubble, helm, flux, humioctl, kustomize and trivy cli tools; autoselects k8s_base scope
 - k8s_ext: (WSL2 only) - minikube, k3d, kind local kubernetes tools; autoselects docker, k8s_base and k8s_dev scopes
 - nodejs: Node.js JavaScript runtime environment using V8 engine
 - pwsh: PowerShell Core and corresponding PS modules; autoselects shell scope
@@ -560,6 +560,7 @@ process {
                 $rel_flux = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_flux.sh $Script:rel_flux
                 $rel_helm = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_helm.sh $Script:rel_helm
                 $rel_hubble = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_hubble.sh $Script:rel_hubble
+                $rel_humioctl = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_humioctl.sh $Script:rel_humioctl
                 $rel_kustomize = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_kustomize.sh $Script:rel_kustomize
                 $rel_trivy = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_trivy.sh $Script:rel_trivy
                 continue

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -25,7 +25,7 @@ List of installation scopes. Valid values:
 - docker: (WSL2 only) - docker, containerd buildx docker-compose
 - gcloud: google-cloud-cli
 - k8s_base: kubectl, kubelogin, k9s, kubecolor, kubectx, kubens
-- k8s_dev: argorollouts, cilium, hubble, helm, flux, kustomize and trivy cli tools; autoselects k8s_base scope
+- k8s_dev: argorollouts, cilium, hubble, helm, flux, humioctl, kustomize and trivy cli tools; autoselects k8s_base scope
 - k8s_ext: (WSL2 only) - minikube, k3d, kind local kubernetes tools; autoselects docker, k8s_base and k8s_dev scopes
 - nodejs: Node.js JavaScript runtime environment using V8 engine
 - pwsh: PowerShell Core and corresponding PS modules; autoselects shell scope
@@ -580,6 +580,7 @@ process {
                 $rel_flux = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_flux.sh $Script:rel_flux
                 $rel_helm = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_helm.sh $Script:rel_helm
                 $rel_hubble = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_hubble.sh $Script:rel_hubble
+                $rel_humioctl = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_humioctl.sh $Script:rel_humioctl
                 $rel_kustomize = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_kustomize.sh $Script:rel_kustomize
                 $rel_trivy = wsl.exe --distribution $Distro --user root --exec .assets/provision/install_trivy.sh $Script:rel_trivy
                 continue


### PR DESCRIPTION
## Summary

- Add `.assets/provision/install_humioctl.sh` to install humio/cli (`humioctl`) from upstream GitHub releases, idempotent on re-run.
- Register `humioctl` in `.assets/scripts/linux_setup.sh` (Linux host entry point) and in the WSL orchestration scripts `wsl/wsl_install.ps1` / `wsl/wsl_setup.ps1` so it can be selected like any other tool.

## Test plan

- [x] `make lint-diff` - all applicable pre-commit hooks green (shellcheck, shfmt, bats)
- [ ] On a Linux/WSL host: `sudo .assets/provision/install_humioctl.sh` installs the latest release; re-running prints `humioctl vX.Y.Z is already latest` and exits 0
- [ ] `humioctl --version` reports the installed version

🤖 Generated with [Claude Code](https://claude.com/claude-code)