### PR TITLE
Backport envy-nx improvements: fixes, certs, tests, CI

### DIFF
--- a/.assets/config/bash_cfg/aliases_git.sh
+++ b/.assets/config/bash_cfg/aliases_git.sh
@@ -1,3 +1,8 @@
+# This file uses bash/zsh syntax (function keyword); skip under POSIX sh (dash)
+# when sourced from /etc/profile.d/ by a non-bash login shell - e.g. the
+# `sh -lc` self-test that the Determinate Nix installer runs.
+[ -n "${BASH_VERSION:-}${ZSH_VERSION:-}" ] || return 0
+
 #region functions
 function git_current_branch {
   git branch --show-current

--- a/.assets/config/bash_cfg/certs.sh
+++ b/.assets/config/bash_cfg/certs.sh
@@ -1,0 +1,14 @@
+# Cert env vars for tools that bypass the system trust store.
+# Bundle files are populated by `wsl/wsl_certs_add.ps1` (Windows host)
+# or by the `cert_intercept` function in functions.sh (in-distro).
+#
+# - ca-custom.crt: MITM proxy / private CA certs only (additive)
+# - ca-bundle.crt: symlink to the system CA bundle (full trust chain)
+if [ -f "$HOME/.config/certs/ca-custom.crt" ]; then
+  export NODE_EXTRA_CA_CERTS="$HOME/.config/certs/ca-custom.crt"
+  export UV_SYSTEM_CERTS=true
+fi
+if [ -f "$HOME/.config/certs/ca-bundle.crt" ]; then
+  export REQUESTS_CA_BUNDLE="$HOME/.config/certs/ca-bundle.crt"
+  export SSL_CERT_FILE="$HOME/.config/certs/ca-bundle.crt"
+fi

--- a/.assets/config/bash_cfg/functions.sh
+++ b/.assets/config/bash_cfg/functions.sh
@@ -2,6 +2,11 @@
 . .assets/config/bash_cfg/functions.sh
 '
 
+# This file uses bash/zsh syntax (function keyword, [[ ]], local); skip under
+# POSIX sh (dash) when sourced from /etc/profile.d/ by a non-bash login shell -
+# e.g. the `sh -lc` self-test that the Determinate Nix installer runs.
+[ -n "${BASH_VERSION:-}${ZSH_VERSION:-}" ] || return 0
+
 # *Function to display system information in a user-friendly format
 function sysinfo() {
   # dot-source os-release file

--- a/.assets/config/bash_cfg/functions.sh
+++ b/.assets/config/bash_cfg/functions.sh
@@ -1,17 +1,24 @@
 : '
 . .assets/config/bash_cfg/functions.sh
 '
+
 # *Function to display system information in a user-friendly format
-function sysinfo {
+function sysinfo() {
   # dot-source os-release file
   . /etc/os-release
   # get cpu info
-  cpu_name="$(sed -En '/^model name\s*: (.+)/{s//\1/;p;q}' /proc/cpuinfo)"
-  cpu_cores="$(sed -En '/^cpu cores\s*: ([0-9]+)/{s//\1/;p;q}' /proc/cpuinfo)"
+  cpu_name="$(sed -En '/^model name[[:space:]]*: (.+)/{
+    s//\1/;p;q
+  }' /proc/cpuinfo)"
+  cpu_cores="$(sed -En '/^cpu cores[[:space:]]*: ([0-9]+)/{
+    s//\1/;p;q
+  }' /proc/cpuinfo)"
   # calculate memory usage
-  mapfile -t mem_inf < <(awk -F ':|kB' '/MemTotal:|MemAvailable:/ {print $2}' /proc/meminfo)
-  mem_total=${mem_inf[0]}
-  mem_used=$((mem_total - mem_inf[1]))
+  local mem_total mem_available
+  read -r mem_total mem_available < <(awk -F ':|kB' \
+    '/MemTotal:/ {t=$2} /MemAvailable:/ {a=$2} \
+    END {gsub(/[[:space:]]/, "", t); gsub(/[[:space:]]/, "", a); print t, a}' /proc/meminfo)
+  mem_used=$((mem_total - mem_available))
   mem_perc=$(awk '{printf "%.0f", $1 * $2 / $3}' <<<"$mem_used 100 $mem_total")
   mem_used=$(awk '{printf "%.2f", $1 / $2 / $3}' <<<"$mem_used 1024 1024")
   mem_total=$(awk '{printf "%.2f", $1 / $2 / $3}' <<<"$mem_total 1024 1024")
@@ -40,105 +47,145 @@ function sysinfo {
 alias gsi='sysinfo'
 
 # *Function for fixing Python SSL certificate issues by adding custom certificates to certifi's cacert.pem
-function fixcertpy {
-  # check if pip and openssl are available
-  type pip &>/dev/null && true || return 1
-  type openssl &>/dev/null && true || return 1
+# Usage: fixcertpy [path ...]
+#   If paths are provided, patches only those cacert.pem files.
+#   If no paths are given, auto-discovers Python certifi bundles (venv, pip).
+function fixcertpy() {
+  # openssl is always needed for serial/fingerprint extraction
+  type openssl &>/dev/null || return 1
 
-  # determine system id
-  SYS_ID="$(sed -En '/^ID.*(fedora|debian|ubuntu|opensuse).*/{s//\1/;p;q}' /etc/os-release)"
-
-  # specify path for installed custom certificates
-  case $SYS_ID in
-  fedora)
-    CERT_PATH='/etc/pki/ca-trust/source/anchors'
-    ;;
-  debian | ubuntu)
-    CERT_PATH='/usr/local/share/ca-certificates'
-    ;;
-  opensuse)
-    CERT_PATH='/usr/share/pki/trust/anchors'
-    ;;
-  *)
-    return 0
-    ;;
-  esac
-
-  # get list of installed certificates
-  mapfile -t cert_paths < <(ls "$CERT_PATH"/*.crt 2>/dev/null || true)
-  if [ "${#cert_paths[@]}" -eq 0 ]; then
-    printf '\033[36mno custom certificates found in \033[4m%s\n\033[0m' "$CERT_PATH" >&2
-    return 0
-  fi
-
-  certify_paths=()
-  # determine venv certifi cacert.pem path
-  if . .venv/bin/activate 2>/dev/null; then
-    [ -x $HOME/.local/bin/uv ] && SHOW=$(uv pip show -f certifi 2>/dev/null) || true
-    [ -n "$SHOW" ] && true || SHOW=$(pip show -f certifi 2>/dev/null)
-    if [ -n "$SHOW" ]; then
-      location=$(echo "$SHOW" | grep -oP '^Location: \K.+')
-      if [ -n "$location" ]; then
-        cacert=$(echo "$SHOW" | grep -oE '\S+cacert\.pem$')
-        if [ -n "$cacert" ]; then
-          certify_paths+=("${location}/${cacert}")
-        fi
+  # load custom certificates into in-memory PEM array
+  local cert_pems=()
+  local CERT_BUNDLE="$HOME/.config/certs/ca-custom.crt"
+  if [ -f "$CERT_BUNDLE" ]; then
+    # parse individual PEM certs from bundle into array
+    local current_pem=""
+    while IFS= read -r line; do
+      if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+        current_pem="$line"
+      elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+        current_pem+=$'\n'"$line"
+        cert_pems+=("$current_pem")
+        current_pem=""
+      elif [[ -n "$current_pem" ]]; then
+        current_pem+=$'\n'"$line"
       fi
-    fi
-  fi
-  # determine pip cacert.pem path
-  SHOW=$(pip show -f pip 2>/dev/null)
-  if [ -n "$SHOW" ]; then
-    location=$(echo "$SHOW" | grep -oP '^Location: \K.+')
-    if [ -n "$location" ]; then
-      cacert=$(echo "$SHOW" | grep -oE '\S+cacert\.pem$')
-      if [ -n "$cacert" ]; then
-        certify_paths+=("${location}/${cacert}")
-      fi
-    fi
-  fi
-
-  # print notification about cacert.pem file(s) update
-  if [ ${#certify_paths[@]} -gt 0 ]; then
-    printf '\e[36madding custom certificates to the following files:\e[0m\n' >&2
+    done <"$CERT_BUNDLE"
   else
-    printf '\e[33mno certify/cacert.pem files found to be updated\e[0m\n' >&2
+    # fall back to distro-specific cert paths
+    local SYS_ID
+    SYS_ID="$(sed -En '/^ID.*(alpine|fedora|debian|ubuntu|opensuse).*/{
+      s//\1/;p;q
+    }' /etc/os-release 2>/dev/null)"
+    local CERT_PATH
+    case ${SYS_ID:-} in
+    alpine)
+      return 0
+      ;;
+    fedora)
+      CERT_PATH='/etc/pki/ca-trust/source/anchors'
+      ;;
+    debian | ubuntu)
+      CERT_PATH='/usr/local/share/ca-certificates'
+      ;;
+    opensuse)
+      CERT_PATH='/usr/share/pki/trust/anchors'
+      ;;
+    *)
+      return 0
+      ;;
+    esac
+    # read each .crt file into the PEM array; `find` instead of glob
+    # so zsh doesn't abort with NOMATCH when the dir is empty
+    while IFS= read -r f; do
+      [ -n "$f" ] && cert_pems+=("$(cat "$f")")
+    done < <(find "$CERT_PATH" -maxdepth 1 -type f -name '*.crt' 2>/dev/null)
+  fi
+
+  if [ "${#cert_pems[@]}" -eq 0 ]; then
+    printf '\033[36mno custom certificates found\033[0m\n' >&2
     return 0
   fi
-  # instantiate variable about number of certificates added
-  cert_count=0
-  # track unique serials that have been added across all certify files
-  declare -A added_serials=()
-  # iterate over certify files
-  for certify in "${certify_paths[@]}"; do
-    echo "${certify//$HOME/\~}" >&2
-    # iterate over installed certificates
-    for path in "${cert_paths[@]}"; do
-      serial=$(openssl x509 -in "$path" -noout -serial -nameopt RFC2253 2>/dev/null | cut -d= -f2)
-      # skip if openssl didn't produce a serial
-      [ -n "$serial" ] || continue
-      if ! grep -qw "$serial" "$certify"; then
-        # add certificate to array (print subject)
-        echo " - $(openssl x509 -in "$path" -noout -subject -nameopt RFC2253 | sed 's/\\//g')" >&2
-        CERT="
-$(openssl x509 -in "$path" -noout -issuer -subject -serial -fingerprint -nameopt RFC2253 | sed 's/\\//g' | xargs -I {} echo "# {}")
-$(openssl x509 -in "$path" -outform PEM)"
-        # append new certificates to certify cacert.pem
-        if [ -w "$certify" ]; then
-          echo "$CERT" >>"$certify"
-        else
-          echo "$CERT" | sudo tee -a "$certify" >/dev/null
+
+  # discover certifi cacert.pem bundles
+  local certifi_paths=()
+  if [ $# -gt 0 ]; then
+    # use explicitly provided paths
+    for p in "$@"; do
+      [ -f "$p" ] && certifi_paths+=("$p")
+    done
+  else
+    # auto-discover Python certifi bundles
+    type pip &>/dev/null || return 1
+    local SHOW location cacert
+    # check venv certifi
+    if . .venv/bin/activate 2>/dev/null; then
+      SHOW=""
+      { [ -x "$HOME/.local/bin/uv" ] || [ -x "$HOME/.nix-profile/bin/uv" ]; } && SHOW=$(uv pip show -f certifi 2>/dev/null) || true
+      [ -n "$SHOW" ] || SHOW=$(pip show -f certifi 2>/dev/null) || true
+      if [ -n "$SHOW" ]; then
+        location=$(echo "$SHOW" | sed -n 's/^Location: //p')
+        if [ -n "$location" ]; then
+          cacert=$(echo "$SHOW" | grep -oE '[^[:space:]]+cacert\.pem$')
+          [ -n "$cacert" ] && certifi_paths+=("${location}/${cacert}")
         fi
-        # increment unique certificate count only once per serial
-        if [ -z "${added_serials[$serial]+x}" ]; then
-          added_serials[$serial]=1
+      fi
+    fi
+    # check pip certifi
+    SHOW=$(pip show -f certifi 2>/dev/null) || true
+    if [ -n "$SHOW" ]; then
+      location=$(echo "$SHOW" | sed -n 's/^Location: //p')
+      if [ -n "$location" ]; then
+        cacert=$(echo "$SHOW" | grep -oE '[^[:space:]]+cacert\.pem$')
+        [ -n "$cacert" ] && certifi_paths+=("${location}/${cacert}")
+      fi
+    fi
+    # check pip's own cacert.pem
+    SHOW=$(pip show -f pip 2>/dev/null) || true
+    if [ -n "$SHOW" ]; then
+      location=$(echo "$SHOW" | sed -n 's/^Location: //p')
+      if [ -n "$location" ]; then
+        cacert=$(echo "$SHOW" | grep -oE '[^[:space:]]+cacert\.pem$')
+        [ -n "$cacert" ] && certifi_paths+=("${location}/${cacert}")
+      fi
+    fi
+  fi
+
+  # exit if no target bundles found
+  if [ ${#certifi_paths[@]} -eq 0 ]; then
+    printf '\e[33mno certifi/cacert.pem bundles found\e[0m\n' >&2
+    return 0
+  fi
+
+  # append custom certificates to each target bundle
+  local cert_count=0
+  local _added_serials=" "
+  local certifi pem serial CERT
+  for certifi in "${certifi_paths[@]}"; do
+    echo "${certifi//$HOME/\~}" >&2
+    for pem in "${cert_pems[@]}"; do
+      serial=$(openssl x509 -noout -serial -nameopt RFC2253 <<<"$pem" 2>/dev/null | cut -d= -f2)
+      [ -n "$serial" ] || continue
+      if ! grep -qw "$serial" "$certifi"; then
+        echo " - $(openssl x509 -noout -subject -nameopt RFC2253 <<<"$pem" | sed 's/\\//g')" >&2
+        CERT="
+$(openssl x509 -noout -issuer -subject -serial -fingerprint -nameopt RFC2253 <<<"$pem" | sed 's/\\//g' | xargs -I {} echo "# {}")
+$(openssl x509 -outform PEM <<<"$pem")"
+        if [ -w "$certifi" ]; then
+          echo "$CERT" >>"$certifi"
+        else
+          printf '\e[33minsufficient permissions to write to %s, run the script as root.\e[0m\n' "$certifi" >&2
+          break
+        fi
+        if [[ " $_added_serials " != *" $serial "* ]]; then
+          _added_serials+="$serial "
           cert_count=$((cert_count + 1))
         fi
       fi
     done
   done
   if [ $cert_count -gt 0 ]; then
-    printf "\e[34madded $cert_count certificate(s) to certifi/cacert.pem file(s)\e[0m\n" >&2
+    printf "\e[34madded $cert_count certificate(s) to certifi bundle(s)\e[0m\n" >&2
   else
     printf '\e[34mno new certificates to add\e[0m\n' >&2
   fi
@@ -146,3 +193,111 @@ $(openssl x509 -in "$path" -outform PEM)"
 
 # alias for backward compatibility
 alias fxcertpy='fixcertpy'
+
+# *Function for intercepting MITM proxy certificates from TLS chain and saving to user cert bundle
+function cert_intercept() {
+  # check if openssl is available
+  if ! type openssl &>/dev/null; then
+    printf '\e[31mopenssl is required but not installed.\e[0m\n' >&2
+    return 1
+  fi
+
+  local _default_host="${NIX_ENV_TLS_PROBE_URL:-https://www.google.com}"
+  _default_host="${_default_host#https://}"
+  _default_host="${_default_host#http://}"
+  local uris=("${@:-$_default_host}")
+  local cert_bundle="$HOME/.config/certs/ca-custom.crt"
+  local cert_count=0
+  local skip_count=0
+
+  # ensure cert directory exists
+  mkdir -p "$HOME/.config/certs"
+
+  # read existing serials from bundle for deduplication
+  local _existing_serials=" "
+  if [ -f "$cert_bundle" ]; then
+    while IFS= read -r serial; do
+      [ -n "$serial" ] && _existing_serials+="$serial "
+    done < <(openssl storeutl -noout -text -certs "$cert_bundle" 2>/dev/null | sed -n 's/.*Serial Number: *//p' || true)
+    # fallback: parse PEM blocks and extract serials individually
+    if [ "$_existing_serials" = " " ]; then
+      local current_pem=""
+      while IFS= read -r line; do
+        if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+          current_pem="$line"
+        elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+          current_pem+=$'\n'"$line"
+          local ser
+          ser=$(openssl x509 -noout -serial <<<"$current_pem" 2>/dev/null | cut -d= -f2)
+          [ -n "$ser" ] && _existing_serials+="$ser "
+          current_pem=""
+        elif [[ -n "$current_pem" ]]; then
+          current_pem+=$'\n'"$line"
+        fi
+      done <"$cert_bundle"
+    fi
+  fi
+
+  for uri in "${uris[@]}"; do
+    printf '\e[36mintercepting certificates from %s...\e[0m\n' "$uri" >&2
+
+    # get full TLS chain
+    local chain_pem
+    chain_pem=$(openssl s_client -showcerts -connect "${uri}:443" </dev/null 2>/dev/null) || {
+      printf '\e[33mfailed to connect to %s\e[0m\n' "$uri" >&2
+      continue
+    }
+
+    # parse individual PEM blocks from chain, skip the first (leaf) cert
+    local pem_blocks=()
+    local current_pem=""
+    local cert_index=0
+    while IFS= read -r line; do
+      if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+        current_pem="$line"
+      elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+        current_pem+=$'\n'"$line"
+        cert_index=$((cert_index + 1))
+        # skip the first cert (leaf/server cert)
+        if [ $cert_index -gt 1 ]; then
+          pem_blocks+=("$current_pem")
+        fi
+        current_pem=""
+      elif [[ -n "$current_pem" ]]; then
+        current_pem+=$'\n'"$line"
+      fi
+    done <<<"$chain_pem"
+
+    # process each intermediate/root cert
+    for pem in "${pem_blocks[@]}"; do
+      local serial
+      serial=$(openssl x509 -noout -serial -nameopt RFC2253 <<<"$pem" 2>/dev/null | cut -d= -f2)
+      [ -n "$serial" ] || continue
+
+      # check for duplicate
+      if [[ " $_existing_serials " == *" $serial "* ]]; then
+        skip_count=$((skip_count + 1))
+        continue
+      fi
+
+      # format cert with header comments and append to bundle
+      local header
+      header=$(openssl x509 -noout -issuer -subject -serial -fingerprint -nameopt RFC2253 <<<"$pem" 2>/dev/null | sed 's/\\//g' | xargs -I {} echo "# {}")
+      local cert_pem
+      cert_pem=$(openssl x509 -outform PEM <<<"$pem" 2>/dev/null)
+
+      printf '%s\n%s\n' "$header" "$cert_pem" >>"$cert_bundle"
+      _existing_serials+="$serial "
+      cert_count=$((cert_count + 1))
+      printf ' \e[32m+ %s\e[0m\n' "$(openssl x509 -noout -subject -nameopt RFC2253 <<<"$pem" 2>/dev/null | sed 's/\\//g')" >&2
+    done
+  done
+
+  # print summary
+  if [ $cert_count -gt 0 ]; then
+    printf '\e[34madded %d certificate(s) to %s\e[0m\n' "$cert_count" "${cert_bundle/$HOME/\~}" >&2
+  else
+    printf '\e[34mno new certificates to add\e[0m\n' >&2
+  fi
+  [ $skip_count -gt 0 ] && printf '\e[90m(%d already existing, skipped)\e[0m\n' "$skip_count" >&2
+}

--- a/.assets/provision/fix_gcloud_certs.sh
+++ b/.assets/provision/fix_gcloud_certs.sh
@@ -23,6 +23,7 @@ debian | ubuntu)
   ;;
 opensuse)
   CERT_PATH='/usr/share/pki/trust/anchors'
+  ;;
 esac
 
 mapfile -t cert_files < <(find "$CERT_PATH" -maxdepth 1 -name '*.crt' 2>/dev/null || true)

--- a/.assets/provision/install_docker.sh
+++ b/.assets/provision/install_docker.sh
@@ -106,7 +106,7 @@ debian)
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     chmod a+r /etc/apt/keyrings/docker.asc
     # add the repository to Apt sources
-    cat <<EOF > /etc/apt/sources.list.d/docker.sources
+    cat <<EOF >/etc/apt/sources.list.d/docker.sources
 Types: deb
 URIs: https://download.docker.com/linux/debian
 Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
@@ -140,7 +140,7 @@ ubuntu)
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
     chmod a+r /etc/apt/keyrings/docker.asc
     # add the repository to Apt sources
-    cat <<EOF > /etc/apt/sources.list.d/docker.sources
+    cat <<EOF >/etc/apt/sources.list.d/docker.sources
 Types: deb
 URIs: https://download.docker.com/linux/ubuntu
 Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")

--- a/.assets/provision/setup_gh_repos.sh
+++ b/.assets/provision/setup_gh_repos.sh
@@ -17,7 +17,7 @@ while [ $# -gt 0 ]; do
 done
 
 # *calculate variables
-read -ra gh_repos <<< "$repos"
+read -ra gh_repos <<<"$repos"
 # calculate workspace name
 if [ -n "$WSL_DISTRO_NAME" ]; then
   ID="$WSL_DISTRO_NAME"

--- a/.assets/provision/setup_gh_ssh.sh
+++ b/.assets/provision/setup_gh_ssh.sh
@@ -4,7 +4,6 @@
 '
 set -euo pipefail
 
-
 if [ $EUID -eq 0 ]; then
   printf '\e[31;1mDo not run the script as root.\e[0m\n' >&2
   exit 1

--- a/.assets/provision/setup_gnome.sh
+++ b/.assets/provision/setup_gnome.sh
@@ -4,7 +4,6 @@
 '
 set -euo pipefail
 
-
 # determine system id
 SYS_ID="$(sed -En '/^ID.*(arch|fedora|debian|ubuntu|opensuse).*/{s//\1/;p;q}' /etc/os-release)"
 

--- a/.assets/provision/setup_profile_allusers.sh
+++ b/.assets/provision/setup_profile_allusers.sh
@@ -52,6 +52,10 @@ if [ -d "$CFG_PATH" ]; then
   fi
   # custom functions
   install -m 0644 "$CFG_PATH/functions.sh" "$PROFILE_PATH"
+  # cert env vars (sourced when ~/.config/certs/ca-*.crt exists)
+  if [ -f "$CFG_PATH/certs.sh" ]; then
+    install -m 0644 "$CFG_PATH/certs.sh" "$PROFILE_PATH"
+  fi
   # clean config folder
   rm -fr "$CFG_PATH"
 fi

--- a/.assets/provision/setup_profile_user.sh
+++ b/.assets/provision/setup_profile_user.sh
@@ -24,6 +24,14 @@ if [ -f "$PROFILE_PATH/aliases.sh" ]; then
 fi
 EOF
 
+# *cert env vars (NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, etc. - sourced when ~/.config/certs/ca-*.crt exists)
+grep -qw 'd/certs.sh' $HOME/.bashrc 2>/dev/null || cat <<EOF >>$HOME/.bashrc
+# cert env vars
+if [ -f "$PROFILE_PATH/certs.sh" ]; then
+  source "$PROFILE_PATH/certs.sh"
+fi
+EOF
+
 # add git aliases
 if ! grep -qw 'd/aliases_git.sh' $HOME/.bashrc 2>/dev/null && type git &>/dev/null; then
   cat <<EOF >>$HOME/.bashrc
@@ -104,4 +112,18 @@ EOF
 elif grep -qw 'oh-my-posh --init' $HOME/.bashrc 2>/dev/null; then
   # convert oh-my-posh initialization to the new API
   sed -i 's/oh-my-posh --init --shell bash/oh-my-posh init bash/' $HOME/.bashrc
+fi
+
+# *VS Code Server env: extensions don't source ~/.bashrc, so re-export
+# cert env vars via ~/.vscode-server/server-env-setup which the server
+# sources at launch (only relevant on remote-SSH / WSL VS Code sessions)
+if [ -f "$PROFILE_PATH/certs.sh" ]; then
+  mkdir -p "$HOME/.vscode-server"
+  ENV_SETUP="$HOME/.vscode-server/server-env-setup"
+  if ! grep -qw 'd/certs.sh' "$ENV_SETUP" 2>/dev/null; then
+    cat <<EOF >>"$ENV_SETUP"
+# cert env vars (managed by setup_profile_user.sh)
+[ -f "$PROFILE_PATH/certs.sh" ] && . "$PROFILE_PATH/certs.sh"
+EOF
+  fi
 fi

--- a/.assets/provision/setup_profile_user.zsh
+++ b/.assets/provision/setup_profile_user.zsh
@@ -67,6 +67,14 @@ if [ -f "$PROFILE_PATH/aliases.sh" ]; then
 fi
 EOF
 
+# *cert env vars (NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, etc. - sourced when ~/.config/certs/ca-*.crt exists)
+grep -qw 'd/certs.sh' "$HOME/.zshrc" 2>/dev/null || cat <<EOF >>"$HOME/.zshrc"
+# cert env vars
+if [ -f "$PROFILE_PATH/certs.sh" ]; then
+  source "$PROFILE_PATH/certs.sh"
+fi
+EOF
+
 # add git aliases
 if ! grep -qw 'd/aliases_git.sh' "$HOME/.zshrc" 2>/dev/null && type git &>/dev/null; then
   cat <<EOF >>"$HOME/.zshrc"

--- a/.assets/provision/setup_ssh.sh
+++ b/.assets/provision/setup_ssh.sh
@@ -7,7 +7,6 @@
 '
 set -euo pipefail
 
-
 # prepare clean $HOME/.ssh directory
 if [ -d "$HOME/.ssh" ]; then
   if [ -f "$HOME/.ssh/id_ed25519" ] && [ -f "$HOME/.ssh/id_ed25519.pub" ]; then

--- a/.assets/provision/upgrade_system.sh
+++ b/.assets/provision/upgrade_system.sh
@@ -28,7 +28,7 @@ fedora)
   ;;
 debian | ubuntu)
   export DEBIAN_FRONTEND=noninteractive
-  apt-get update && apt-get dist-upgrade -qy --allow-downgrades --allow-remove-essential --allow-change-held-packages
+  apt-get update -qq && apt-get dist-upgrade -qqy --allow-downgrades --allow-remove-essential --allow-change-held-packages
   ;;
 opensuse)
   zypper --gpg-auto-import-keys refresh && zypper --non-interactive dup -y

--- a/.assets/scripts/linux_setup.sh
+++ b/.assets/scripts/linux_setup.sh
@@ -253,7 +253,7 @@ printf "\e[96msetting up profile for current user...\e[0m\n"
 .assets/provision/setup_profile_user.sh
 # install powershell modules
 if [ -f /usr/bin/pwsh ]; then
-  cmnd="Import-Module (Resolve-Path './modules/InstallUtils'); Invoke-GhRepoClone -OrgRepo 'szymonos/ps-modules'"
+  cmnd="Import-Module (Resolve-Path './modules/InstallUtils'); Invoke-GhRepoClone -OrgRepo 'szymonos/ps-modules' -WarningAction SilentlyContinue"
   cloned=$(pwsh -nop -c "$cmnd")
   if [ $cloned -gt 0 ]; then
     printf "\e[96minstalling ps-modules...\e[0m\n"

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = lf
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.{sh,sh.in}]
+[*.{bash,bats,sh,sh.in}]
 indent_size = 2
 trim_trailing_whitespace = true
 

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -1,0 +1,149 @@
+name: Linux Integration Test
+
+# Builds the Ubuntu Dockerfile end-to-end (which runs linux_setup.sh) and runs
+# verification commands against the resulting image. ~10 min runtime.
+#
+# Triggers:
+#   1. Manual: Actions tab -> "Run workflow" button.
+#   2. PR label: add "test:integration" label to a PR.
+#   3. Push to PR: runs on push if the PR already has the "test:integration" label.
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'push' }}
+  cancel-in-progress: true
+
+jobs:
+  test-linux:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'test:integration') ||
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'test:integration'))
+
+    name: linux_setup.sh (Ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (runs linux_setup.sh end-to-end)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .assets/docker/Dockerfile
+          load: true
+          tags: lss-test:latest
+          push: false
+
+      # ---- verification (continue-on-error so summary shows full picture) ----
+      - name: Verify pwsh on PATH
+        id: pwsh
+        continue-on-error: true
+        run: docker run --rm --entrypoint bash lss-test:latest -c 'command -v pwsh && pwsh --version'
+
+      - name: Verify oh-my-posh on PATH
+        id: omp
+        continue-on-error: true
+        run: docker run --rm --entrypoint bash lss-test:latest -c 'command -v oh-my-posh && oh-my-posh --version'
+
+      - name: Verify /etc/profile.d/ files source cleanly under dash
+        # Regression check for the POSIX-guard fix on aliases_git.sh and
+        # functions.sh - the Determinate Nix installer's `sh -lc` self-test
+        # used to break here on Debian/Ubuntu (where /bin/sh is dash).
+        id: dash
+        continue-on-error: true
+        run: |
+          docker run --rm --entrypoint bash lss-test:latest -c '
+            set -e
+            failed=0
+            for f in /etc/profile.d/aliases.sh /etc/profile.d/aliases_git.sh \
+                     /etc/profile.d/aliases_kubectl.sh /etc/profile.d/functions.sh \
+                     /etc/profile.d/certs.sh; do
+              if [ -f "$f" ]; then
+                if dash -c ". \"$f\""; then
+                  printf "  \e[32mok\e[0m   : %s\n" "$f"
+                else
+                  printf "  \e[31mFAIL\e[0m : %s\n" "$f"
+                  failed=1
+                fi
+              fi
+            done
+            [ "$failed" -eq 0 ]
+          '
+
+      - name: Verify bash sources /etc/profile.d/ and exposes functions
+        id: bash
+        continue-on-error: true
+        run: |
+          docker run --rm --entrypoint bash lss-test:latest -lc '
+            set -e
+            for fn in sysinfo fixcertpy cert_intercept git_current_branch git_resolve_branch; do
+              if declare -F "$fn" >/dev/null; then
+                printf "  \e[32mok\e[0m   : %s defined\n" "$fn"
+              else
+                printf "  \e[31mFAIL\e[0m : %s NOT defined\n" "$fn"
+                exit 1
+              fi
+            done
+          '
+
+      # ---- summary -----------------------------------------------------------
+      - name: Show verification summary
+        if: always()
+        run: |
+          set -euo pipefail
+
+          gh_to_emoji() {
+            case "$1" in
+              success) echo "✅" ;;
+              failure) echo "❌" ;;
+              skipped) echo "⏭️" ;;
+              *) echo "❓" ;;
+            esac
+          }
+
+          echo ""
+          echo "Verification results:"
+          any_failed=false
+
+          while IFS= read -r entry; do
+            entry="${entry#"${entry%%[![:space:]]*}"}"
+            [ -z "$entry" ] && continue
+            id="${entry%%:*}"
+            label="${entry#*:}"
+            case "$id" in
+              pwsh) outcome="${{ steps.pwsh.outcome }}" ;;
+              omp)  outcome="${{ steps.omp.outcome }}" ;;
+              dash) outcome="${{ steps.dash.outcome }}" ;;
+              bash) outcome="${{ steps.bash.outcome }}" ;;
+              *)    outcome="unknown" ;;
+            esac
+            echo "$(gh_to_emoji "$outcome") $label : $outcome"
+            [ "$outcome" = "failure" ] && any_failed=true
+          done <<'STEPS'
+            pwsh:pwsh on PATH
+            omp:oh-my-posh on PATH
+            dash:/etc/profile.d/ sources under dash
+            bash:bash login shell exposes functions
+          STEPS
+
+          echo ""
+          if [ "$any_failed" = "true" ]; then
+            echo "❌ Some verification steps failed"
+            exit 1
+          else
+            echo "✅ All verification steps passed"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Unit Tests
+
+# Runs on every PR and on push to main.
+# Bats + Pester are fast (~2 min total) so no label gating needed; they catch
+# regressions in module functions (logs.ps1, common.ps1, certs.ps1) and the
+# shell helpers (sysinfo, fixcertpy, cert_intercept).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-unit:
+    name: bats + Pester
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: Ensure Pester 5+ available
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge '5.0' })) {
+            Install-Module Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+
+      - name: Show versions
+        run: |
+          bats --version
+          pwsh --version
+          pwsh -nop -c "Get-Module -ListAvailable Pester | Select-Object -First 1 | Format-Table Name, Version"
+
+      - name: Run unit tests
+        run: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
       - id: markdownlint-cli2
         files: \.md$
         exclude: /copilot-instructions\.md
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        exclude: \.zsh$
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
         entry: python3 -m tests.hooks.gremlins
         language: system
         types: [text]
+      - id: align-tables
+        name: align markdown tables
+        entry: python3 -m tests.hooks.align_tables
+        language: system
+        files: \.md$
+        exclude: /copilot-instructions\.md
       - id: check-zsh-compat
         name: Check shell-sourced scripts for zsh compatibility
         entry: python3 -m tests.hooks.check_zsh_compat

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,24 @@ repos:
         entry: python3 -m tests.hooks.gremlins
         language: system
         types: [text]
+      - id: check-zsh-compat
+        name: Check shell-sourced scripts for zsh compatibility
+        entry: python3 -m tests.hooks.check_zsh_compat
+        language: system
+        files: \.assets/config/bash_cfg/.*\.sh$
+        types: [file]
+      - id: bats-tests
+        name: Run bats unit tests for changed files
+        entry: python3 -m tests.hooks.run_bats
+        language: system
+        types: [file]
+        pass_filenames: true
+      - id: pester-tests
+        name: Run Pester unit tests for changed files
+        entry: python3 -m tests.hooks.run_pester
+        language: system
+        types: [file]
+        pass_filenames: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/BACKPORT.md
+++ b/BACKPORT.md
@@ -1,0 +1,416 @@
+# Backporting from envy-nx
+
+This repo (`linux-setup-scripts`) and [`envy-nx`](https://github.com/szymonos/envy-nx)
+share a chunk of code: most of `modules/`, all of `wsl/`, large parts of
+`.assets/config/` and `.assets/provision/`, and the `tests/` infrastructure.
+envy-nx is the cross-platform Nix descendant and is in rapid (daily-ish)
+development. This repo cherry-picks improvements that apply to its
+**parallel functionality** - code that exists in both repos and serves the
+same purpose.
+
+This document is the procedure an agent (human or AI) follows when asked to
+"backport recent envy-nx improvements." There is **no upstream marker** on
+envy-nx commits or CHANGELOG entries - every candidate is evaluated at runtime
+against the rules below.
+
+## Last ported through
+
+```text
+envy-nx commit: <SHA>      # bump on each backport PR; agent reads CHANGELOG entries newer than this
+envy-nx tag:    <TAG>      # nearest released tag for human readability
+ported on:      <YYYY-MM-DD>
+```
+
+When you finish a backport PR, update all three lines and include the bump in
+the final commit. The agent uses the SHA as the cut-off; everything before it
+is already considered ported (or deliberately skipped).
+
+## Procedure
+
+1. **Verify envy-nx is checked out and current.** Default location is
+   `~/source/repos/szymonos/envy-nx`. Run `git -C ~/source/repos/szymonos/envy-nx pull`
+   before starting. If the repo isn't there, clone it first (read-only is fine).
+
+2. **Baseline this repo.** Run `make lint && make test`. Do not start with a
+   dirty or red baseline - finish open work first.
+
+3. **Compute the candidate list.** Read envy-nx's `CHANGELOG.md` from the
+   entry **after** the "Last ported through" SHA up to the unreleased section.
+   Each bullet is a candidate. Aim for chronological order (oldest first) so
+   later entries that build on earlier ones make sense.
+
+4. **Evaluate each candidate** against the rules in
+   *Eligibility* below. Sort into three buckets:
+   - **Port** - applies to parallel functionality, no nix coupling
+   - **Skip** - nix-only, refactor that doesn't apply, or removes something we still need
+   - **Investigate** - touches a parallel file but the diff might mix nix-coupled
+     code; read the actual file diff before deciding
+
+5. **Group ports into logical PRs.** Bug fixes together; perf/quality together;
+   net-new functionality on its own. Aim for 3-7 commits per PR, one logical
+   change each. Use a branch named `chore/port-envy-nx-<topic>` (e.g.
+   `chore/port-envy-nx-fixes-may`).
+
+6. **Apply each change.** For each commit:
+   - Read the corresponding envy-nx file fully
+   - Read this repo's file fully
+   - Identify the *delta* that's the improvement (vs the structural divergence)
+   - Apply via the `Edit` tool - never overwrite a whole file unless it's a
+     pure copy (e.g., a Pester test file)
+   - For test files: copy the whole file, then adapt the dot-source / source
+     paths via the path mapping
+   - For envy-nx file headers that reference `nix/setup.sh` or `~/.nix-profile`,
+     rewrite them to match this repo's entry points (`linux_setup.sh`,
+     `wsl_setup.ps1`)
+
+7. **Validate after each commit.**
+   - `make lint` for any change
+   - `make test` if you touched code under `modules/`, `.assets/config/`,
+     or `tests/`
+   - For shell config under `.assets/config/bash_cfg/`: run
+     `dash -c '. <file>'` to confirm the POSIX-guard pattern still holds
+     (these files are installed to `/etc/profile.d/` and sourced by dash)
+
+8. **Bump the "Last ported through" pointer** in this file as the final
+   commit of the PR.
+
+9. **Open the PR with the integration test triggered.**
+
+   ```bash
+   gh pr create --title "..." --body "..."
+   gh pr edit --add-label test:integration
+   ```
+
+## Eligibility
+
+### Port if all of these are true
+
+- The CHANGELOG entry mentions a file/function that maps to a path in the
+  *Path mapping* table below
+- The change is a bug fix, perf improvement, hardening, or quality fix to an
+  existing parallel function
+- The diff doesn't reference nix-only symbols (see *Nix coupling signals* below)
+- If it adds something new (function, file, env var), it's additive and useful
+  to a non-nix WSL/Linux user
+
+### Skip if any of these are true
+
+- The CHANGELOG entry's only touched files are in the *Skip-list* below
+- The change is a refactor of an envy-nx-only structure (`nx.sh` family split,
+  `nx_surface.json`, etc.)
+- The change relies on `nix profile`, `flake.nix`, `~/.nix-profile/`, or any
+  `nx` CLI verb
+- The change removes something this repo still uses (e.g., envy-nx removed
+  `install_pwsh.sh` because pwsh comes from nix; we still need the script)
+- The change is macOS-specific (this repo targets Linux/WSL only)
+- The change is purely cosmetic to envy-nx's CHANGELOG, docs, or release tooling
+
+### Investigate (read the actual diff before deciding)
+
+- File touched is in the path-mapping table BUT envy-nx may have nix-coupled
+  helpers in the same file. Common in `wsl_setup.ps1`, `setup_common.sh`,
+  `gh.sh`, `git.sh`, `functions.sh`. Extract the non-nix delta or skip if it's
+  too entangled.
+
+### Nix coupling signals
+
+If the diff contains any of these, the relevant block is nix-coupled - exclude
+it from the port even if surrounding code is shared:
+
+| Signal                  | Examples                                                                                                                                                                                                 |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Path references         | `~/.nix-profile/`, `~/.config/nix-env/`, `/nix/store`, `nix/...`                                                                                                                                         |
+| Env vars                | `NIX_*`, `NIX_SSL_CERT_FILE`, `NIX_ENV_*`                                                                                                                                                                |
+| CLI calls               | `nix` (as command), `nx` (as command), `nix profile`, `nix flake`, `nix-env`, `nx_doctor.sh`                                                                                                             |
+| Files / declarations    | `flake.nix`, `flake.lock`, `config.nix`, `*.nix`, `nx_surface.json`                                                                                                                                      |
+| Module references       | `do-common`, `do-linux`, `do-az`, `psm-windows`, `aliases-git`, `aliases-kubectl` (envy-nx vendors these; this repo clones from `szymonos/ps-modules` at runtime - see *Module layout difference* below) |
+| Phase-library structure | `nix/lib/io.sh`, `nix/lib/phases/*.sh`, `_io_run`, `_io_nix`, `phase_*` functions                                                                                                                        |
+| Scope system            | `scopes.json`, `scopes.sh`, `resolve_scope_deps`, `sort_scopes`, scope `--` flags like `--shell`, `--python`                                                                                             |
+| Managed-block pattern   | `manage_block`, `# >>> nix-env managed >>>`, `# >>> managed env >>>`                                                                                                                                     |
+
+## Path mapping
+
+envy-nx has a different module / asset layout. Translate paths via this table.
+A blank "this repo" cell means **no equivalent - skip**.
+
+### Modules
+
+| envy-nx                                                    | this repo                                                                                                                                              |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `modules/InstallUtils/Functions/git.ps1`                   | `modules/InstallUtils/Functions/git.ps1`                                                                                                               |
+| `modules/do-common/Functions/common.ps1`                   | `modules/SetupUtils/Functions/common.ps1`                                                                                                              |
+| `modules/do-common/Functions/logs.ps1`                     | `modules/SetupUtils/Functions/logs.ps1`                                                                                                                |
+| `modules/do-common/Functions/certs.ps1`                    | `modules/SetupUtils/Functions/certs.ps1`                                                                                                               |
+| `modules/do-common/Functions/cli.ps1`                      | (no equivalent - evaluate on demand)                                                                                                                   |
+| `modules/do-common/Functions/python.ps1`                   | (no equivalent)                                                                                                                                        |
+| `modules/do-common/Functions/dotnet.ps1`                   | (no equivalent)                                                                                                                                        |
+| `modules/do-common/Functions/net.ps1`                      | (no equivalent)                                                                                                                                        |
+| `modules/psm-windows/Functions/common.ps1`                 | `modules/InstallUtils/Functions/common.ps1` (`Invoke-CommandRetry`, `Join-Str`, `Test-IsAdmin`, `Update-SessionEnvironmentPath`)                       |
+| `modules/SetupUtils/Functions/wsl.ps1`                     | `modules/SetupUtils/Functions/wsl.ps1` (only `Get-WslDistro`, `Set-WslConf` - scope helpers are nix-only)                                              |
+| `modules/{do-az,do-linux,aliases-git,aliases-kubectl}/...` | (no equivalent - these are vendored in envy-nx; this repo clones `szymonos/ps-modules` at runtime in `linux_setup.sh`. See *Module layout difference*) |
+
+### Shell config
+
+| envy-nx                                           | this repo                                    |
+| ------------------------------------------------- | -------------------------------------------- |
+| `.assets/config/shell_cfg/functions.sh`           | `.assets/config/bash_cfg/functions.sh`       |
+| `.assets/config/shell_cfg/aliases.sh`             | `.assets/config/bash_cfg/aliases.sh`         |
+| `.assets/config/shell_cfg/aliases_git.sh`         | `.assets/config/bash_cfg/aliases_git.sh`     |
+| `.assets/config/shell_cfg/aliases_kubectl.sh`     | `.assets/config/bash_cfg/aliases_kubectl.sh` |
+| `.assets/config/shell_cfg/certs.sh`               | `.assets/config/bash_cfg/certs.sh`           |
+| `.assets/config/shell_cfg/aliases_nix.sh`         | (skip - nix-only)                            |
+| `.assets/config/shell_cfg/completions.{bash,zsh}` | (skip - `nx` CLI completions)                |
+| `.assets/config/pwsh_cfg/_aliases_nix.ps1`        | (skip - nix-only)                            |
+| `.assets/config/pwsh_cfg/profile_nix.ps1`         | (skip - nix-only)                            |
+| `.assets/config/omp_cfg/`                         | `.assets/config/omp_cfg/`                    |
+| `.assets/config/starship_cfg/`                    | (skip - this repo uses oh-my-posh only)      |
+
+### WSL orchestration
+
+| envy-nx                    | this repo                  |
+| -------------------------- | -------------------------- |
+| `wsl/wsl_setup.ps1`        | `wsl/wsl_setup.ps1`        |
+| `wsl/wsl_certs_add.ps1`    | `wsl/wsl_certs_add.ps1`    |
+| `wsl/wsl_distro_move.ps1`  | `wsl/wsl_distro_move.ps1`  |
+| `wsl/wsl_files_copy.ps1`   | `wsl/wsl_files_copy.ps1`   |
+| `wsl/wsl_flags_manage.ps1` | `wsl/wsl_flags_manage.ps1` |
+| `wsl/wsl_install.ps1`      | `wsl/wsl_install.ps1`      |
+| `wsl/wsl_network_fix.ps1`  | `wsl/wsl_network_fix.ps1`  |
+| `wsl/wsl_restart.ps1`      | `wsl/wsl_restart.ps1`      |
+| `wsl/wsl_systemd.ps1`      | `wsl/wsl_systemd.ps1`      |
+| `wsl/wsl_win_path.ps1`     | `wsl/wsl_win_path.ps1`     |
+| `wsl/wsl_wslg.ps1`         | `wsl/wsl_wslg.ps1`         |
+| `wsl/pwsh_setup.ps1`       | `wsl/pwsh_setup.ps1`       |
+
+The `wsl_setup.ps1` files are highly divergent (envy-nx delegates to nix, this
+repo runs the per-tool installers). Only port surgical line-level fixes; never
+copy whole sections.
+
+### Provision / setup scripts
+
+envy-nx has restructured provisioning into `.assets/{provision,setup,check,fix}/`.
+This repo keeps them all flat under `.assets/provision/`.
+
+| envy-nx                                    | this repo                                                                                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `.assets/provision/install_base.sh`        | `.assets/provision/install_base.sh` (very different - envy-nx defers most to nix; ours installs the full set. Only port narrow fixes) |
+| `.assets/provision/install_gh.sh`          | `.assets/provision/install_gh.sh`                                                                                                     |
+| `.assets/provision/install_copilot.sh`     | `.assets/provision/install_copilot.sh`                                                                                                |
+| `.assets/provision/install_distrobox.sh`   | `.assets/provision/install_distrobox.sh`                                                                                              |
+| `.assets/provision/install_docker.sh`      | `.assets/provision/install_docker.sh`                                                                                                 |
+| `.assets/provision/install_podman.sh`      | `.assets/provision/install_podman.sh`                                                                                                 |
+| `.assets/provision/install_zsh.sh`         | `.assets/provision/install_zsh.sh`                                                                                                    |
+| `.assets/provision/install_azurecli_uv.sh` | `.assets/provision/install_azurecli_uv.sh`                                                                                            |
+| `.assets/provision/install_nix.sh`         | (skip - nix only)                                                                                                                     |
+| `.assets/provision/upgrade_system.sh`      | `.assets/provision/upgrade_system.sh`                                                                                                 |
+| `.assets/check/check_distro.sh`            | `.assets/provision/check_distro.sh`                                                                                                   |
+| `.assets/check/check_dns.sh`               | `.assets/provision/check_dns.sh`                                                                                                      |
+| `.assets/check/check_ssl.sh`               | `.assets/provision/check_ssl.sh`                                                                                                      |
+| `.assets/fix/fix_azcli_certs.sh`           | `.assets/provision/fix_azcli_certs.sh`                                                                                                |
+| `.assets/fix/fix_gcloud_certs.sh`          | `.assets/provision/fix_gcloud_certs.sh`                                                                                               |
+| `.assets/fix/fix_no_file.sh`               | `.assets/provision/fix_no_file.sh`                                                                                                    |
+| `.assets/fix/fix_nodejs_certs.sh`          | `.assets/provision/fix_nodejs_certs.sh`                                                                                               |
+| `.assets/fix/fix_secure_path.sh`           | `.assets/provision/fix_secure_path.sh`                                                                                                |
+| `.assets/setup/setup_gh_https.sh`          | `.assets/provision/setup_gh_https.sh`                                                                                                 |
+| `.assets/setup/setup_gh_repos.sh`          | `.assets/provision/setup_gh_repos.sh`                                                                                                 |
+| `.assets/setup/setup_ssh.sh`               | `.assets/provision/setup_ssh.sh`                                                                                                      |
+| `.assets/setup/set_authorized_keys.sh`     | `.assets/provision/set_authorized_keys.sh`                                                                                            |
+| `.assets/setup/set_ulimits.sh`             | `.assets/provision/set_ulimits.sh`                                                                                                    |
+| `.assets/setup/setup_profile_user.zsh`     | `.assets/provision/setup_profile_user.zsh`                                                                                            |
+| `.assets/setup/setup_profile_user.ps1`     | (no equivalent - envy-nx-specific pwsh provenance)                                                                                    |
+| `.assets/setup/setup_common.sh`            | (no direct equivalent - this repo inlines its logic in `linux_setup.sh`'s tail)                                                       |
+| `.assets/setup/autoexec.sh`                | `.assets/provision/autoexec.sh`                                                                                                       |
+| `.assets/setup/update_psresources.ps1`     | `.assets/provision/update_psresources.ps1`                                                                                            |
+
+This repo also has many `install_*.sh` scripts that envy-nx removed (because
+nix replaces them). Don't port "removed" entries - those scripts are still
+in active use here.
+
+### Tests / hooks
+
+| envy-nx                                                                                                                                                                                                                                                    | this repo                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/pester/{ConvertCfg,ConvertPEM,GetLogLine,InvokeCommandRetry,JoinStr}.Tests.ps1`                                                                                                                                                                     | same paths (dot-source paths differ - see below)                                                                                |
+| `tests/pester/NxCompleter.Tests.ps1`                                                                                                                                                                                                                       | (skip - `nx` CLI)                                                                                                               |
+| `tests/pester/Scopes.Tests.ps1`                                                                                                                                                                                                                            | (skip - scope system)                                                                                                           |
+| `tests/pester/WslSetup.Tests.ps1`                                                                                                                                                                                                                          | `tests/pester/WslSetup.Tests.ps1` (envy-nx version mocks nix-mode dispatch - substantive rewrite needed; investigate carefully) |
+| `tests/bats/{test_functions,test_fixcertpy_discovery,test_git_aliases,test_gh_helpers}.bats`                                                                                                                                                               | same paths (source paths differ)                                                                                                |
+| `tests/bats/test_nix_setup.bats`, `test_nx_*.bats`, `test_overlay.bats`, `test_profile_block.bats`, `test_profile_migration.bats`, `test_pwsh_nop.bats`, `test_install_record.bats`, `test_uninstaller.bats`, `test_conda_remove.bats`, `test_scopes.bats` | (skip - all nix/scope-specific)                                                                                                 |
+| `tests/hooks/run_pester.py`                                                                                                                                                                                                                                | `tests/hooks/run_pester.py`                                                                                                     |
+| `tests/hooks/run_bats.py`                                                                                                                                                                                                                                  | `tests/hooks/run_bats.py`                                                                                                       |
+| `tests/hooks/check_zsh_compat.py`                                                                                                                                                                                                                          | `tests/hooks/check_zsh_compat.py`                                                                                               |
+| `tests/hooks/check_bash32.py`                                                                                                                                                                                                                              | (skip - bash 3.2 is for macOS)                                                                                                  |
+| `tests/hooks/check_changelog.py`                                                                                                                                                                                                                           | (skip - this repo has no CHANGELOG.md)                                                                                          |
+| `tests/hooks/check_nx_*.py`, `gen_nx_completions.py`, `nix_closure_to_spdx.py`                                                                                                                                                                             | (skip - nix/nx)                                                                                                                 |
+| `tests/hooks/validate_scopes.py`                                                                                                                                                                                                                           | (skip - scope system)                                                                                                           |
+| `tests/hooks/gremlins.py`                                                                                                                                                                                                                                  | `tests/hooks/gremlins.py`                                                                                                       |
+| `tests/hooks/align_tables.py`                                                                                                                                                                                                                              | (currently skipped - could port if markdown table maintenance becomes a pain)                                                   |
+| `tests/hooks/validate_docs_words.py`                                                                                                                                                                                                                       | (skip - needs cspell + docs/ structure)                                                                                         |
+
+When porting Pester tests, adapt the dot-source path:
+
+```text
+envy-nx:    . $PSScriptRoot/../../modules/do-common/Functions/common.ps1
+this repo:  . $PSScriptRoot/../../modules/SetupUtils/Functions/common.ps1
+```
+
+When porting bats tests, adapt the source directive:
+
+```text
+envy-nx:    source "$BATS_TEST_DIRNAME/../../.assets/config/shell_cfg/functions.sh"
+this repo:  source "$BATS_TEST_DIRNAME/../../.assets/config/bash_cfg/functions.sh"
+```
+
+### CI
+
+| envy-nx                               | this repo                                                                                                  |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/repo_checks.yml`   | `.github/workflows/repo_checks.yml`                                                                        |
+| `.github/workflows/test_linux.yml`    | `.github/workflows/test_linux.yml` (very different - envy-nx exercises nix matrix, ours builds Dockerfile) |
+| `.github/workflows/tests.yml`         | `.github/workflows/tests.yml` (envy-nx may not have this; we added on bootstrap)                           |
+| `.github/workflows/test_macos.yml`    | (skip - Linux/WSL only)                                                                                    |
+| `.github/workflows/release.yml`       | (skip - no signed releases here)                                                                           |
+| `.github/workflows/docs-gh-pages.yml` | (skip - no docs site)                                                                                      |
+
+## Skip-list (never eligible)
+
+| Path                                                                                                              | Reason                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `nix/` (entire dir)                                                                                               | Nix path entry point                                                                        |
+| `.assets/lib/` (entire dir)                                                                                       | envy-nx-only restructure (helpers, scopes, profile_block, env_block, certs, nx_doctor, nx*) |
+| `.assets/config/shell_cfg/aliases_nix.sh`                                                                         | nix aliases                                                                                 |
+| `.assets/config/shell_cfg/completions.{bash,zsh}`                                                                 | `nx` CLI tab completion                                                                     |
+| `.assets/config/pwsh_cfg/_aliases_nix.ps1`                                                                        | nix aliases (pwsh)                                                                          |
+| `.assets/config/pwsh_cfg/profile_nix.ps1`                                                                         | nix profile template                                                                        |
+| `.assets/config/starship_cfg/`                                                                                    | starship prompt (this repo uses oh-my-posh)                                                 |
+| `console/`                                                                                                        | envy-nx maintainer tooling                                                                  |
+| `design/`                                                                                                         | envy-nx design notes                                                                        |
+| `docs/`                                                                                                           | envy-nx mkdocs site (this repo's `docs/` is separate)                                       |
+| `mkdocs.yml` (envy-nx)                                                                                            | docs site config                                                                            |
+| `pyproject.toml` (envy-nx)                                                                                        | nix path packaging - this repo doesn't need one                                             |
+| `uv.lock`                                                                                                         | docs site dependency lock                                                                   |
+| `tests/bats/test_{nix_setup,nx_*,overlay,profile_*,pwsh_nop,install_record,uninstaller,conda_remove,scopes}.bats` | nix/scope tests                                                                             |
+| `tests/pester/{NxCompleter,Scopes}.Tests.ps1`                                                                     | `nx` CLI / scope tests                                                                      |
+| `tests/hooks/{check_bash32,check_changelog,check_nx_*,gen_nx_completions,nix_closure_to_spdx,validate_scopes}.py` | nix/scope/changelog hooks                                                                   |
+| `.github/workflows/{test_macos,release,docs-gh-pages}.yml`                                                        | macOS / release / docs                                                                      |
+
+## Hard rules
+
+- **Never copy nix-coupled code** even if it lives in a path-mapped file. Use
+  the *Nix coupling signals* table to identify, then exclude that block.
+- **Tests come first** when porting a function fix. Port the test for the
+  function in the same commit. The test validates the port worked.
+- **One logical change per commit.** Don't bundle unrelated fixes. Reviewer
+  and `git bisect` need them separable.
+- **Adapt comments and headers.** envy-nx file headers reference `nix/setup.sh`
+  and `~/.nix-profile`; rewrite them to reference this repo's entry points
+  (`linux_setup.sh`, `wsl_setup.ps1`).
+- **Ports are additive by default.** If envy-nx removed something we still
+  need (e.g., `install_pwsh.sh`), don't remove it here.
+- **A ported test that fails on this repo's code is a real bug.** Fix the bug,
+  don't disable the test. (Bootstrap example: porting `JoinStr.Tests.ps1`
+  surfaced a missing `DefaultParameterSetName='None'` on `Join-Str` - fixed
+  in the same commit.)
+- **POSIX-guard new bash files** that get installed to `/etc/profile.d/`. If
+  the file uses bash-only syntax (`function`, `[[ ]]`, `local`, `+=`), add
+  `[ -n "${BASH_VERSION:-}${ZSH_VERSION:-}" ] || return 0` at the top so dash
+  no-ops cleanly when sourcing it. Verify with `dash -c '. <file>'`. (See
+  `aliases_git.sh`, `functions.sh`.)
+- **Don't add nix-only directories.** No `nix/`, `.assets/lib/`, scope files.
+  These belong only in envy-nx.
+
+## Module layout difference
+
+envy-nx vendors several PowerShell modules under `modules/` (`do-common`,
+`do-az`, `do-linux`, `psm-windows`, `aliases-git`, `aliases-kubectl`). This
+repo does **not** vendor them - `linux_setup.sh`'s tail clones
+[`szymonos/ps-modules`](https://github.com/szymonos/ps-modules) at runtime
+and installs the relevant ones via `module_manage.ps1`.
+
+Practical implication: when envy-nx changes a function in `modules/do-common/`,
+the actual fix lives upstream in `szymonos/ps-modules`. envy-nx's vendored
+copy is a snapshot. To port the fix to this repo:
+
+1. Apply it to the corresponding function in `modules/SetupUtils/` or
+   `modules/InstallUtils/` (the module names this repo uses pre-clone), AND
+2. Optionally raise the same fix in `szymonos/ps-modules` (out of scope for
+   this doc; mention in the PR body if relevant)
+
+## Examples
+
+### Example 1: pure copy with path adaptation (Pester test)
+
+envy-nx CHANGELOG entry: *added Pester tests for `Get-LogLine` covering the
+`$ctx` regression*
+
+1. Read `~/source/repos/szymonos/envy-nx/tests/pester/GetLogLine.Tests.ps1`
+2. Copy to `tests/pester/GetLogLine.Tests.ps1`
+3. Change the dot-source line:
+   `. $PSScriptRoot/../../modules/do-common/Functions/logs.ps1`
+   → `. $PSScriptRoot/../../modules/SetupUtils/Functions/logs.ps1`
+4. Run `pwsh -nop -c 'Invoke-Pester tests/pester/GetLogLine.Tests.ps1'`
+5. Commit
+
+### Example 2: substantive port of a function (cert_intercept)
+
+envy-nx CHANGELOG entry: *added `cert_intercept` shell function for capturing
+MITM proxy certs from TLS chain*
+
+1. Read `~/source/repos/szymonos/envy-nx/.assets/config/shell_cfg/functions.sh`
+2. Locate the `cert_intercept` function definition + its dependencies
+3. Verify it has no nix coupling (greps for `~/.nix-profile`, `nix` calls,
+   `NIX_*` come up clean - only `NIX_ENV_TLS_PROBE_URL` reference, which is
+   optional via `${VAR:-default}` fallback)
+4. Add the function to `.assets/config/bash_cfg/functions.sh` after the
+   existing `fixcertpy` definition; keep the envy-nx version verbatim
+5. Wire any new state into consumers - e.g., the function writes to
+   `~/.config/certs/ca-custom.crt`; verify `setup_profile_user.sh` sources
+   `certs.sh` so env vars get exported
+6. Run `bats tests/bats/test_functions.bats` (which covers `cert_intercept`)
+7. Commit
+
+### Example 3: surgical line fix in a divergent file
+
+envy-nx CHANGELOG entry: *quiet `apt` output during system upgrade*
+
+1. Read `~/source/repos/szymonos/envy-nx/.assets/provision/upgrade_system.sh`
+2. Read this repo's `.assets/provision/upgrade_system.sh`
+3. The two files are otherwise identical - the only delta is the `-qq` flag
+   on `apt-get update` and `-qqy` on `dist-upgrade`
+4. Apply the one-line edit via `Edit` tool
+5. Commit
+
+### Example 4: skip - nix-only refactor
+
+envy-nx CHANGELOG entry: *split `nx.sh` into family files (`nx_pkg.sh`,
+`nx_scope.sh`, `nx_profile.sh`, `nx_lifecycle.sh`)*
+
+1. The touched files are all in `.assets/lib/` (envy-nx-only)
+2. The `nx` CLI doesn't exist in this repo
+3. Skip. No port action; no entry in the PR.
+
+### Example 5: investigate - divergent file with mixed-coupling diff
+
+envy-nx CHANGELOG entry: *`wsl_setup.ps1`: pre-populate gh config from default
+distro via direct `cat` of hosts.yml*
+
+1. Read both `wsl_setup.ps1` files
+2. The diff has two clusters: (a) the `cat ~/.config/gh/hosts.yml` line -
+   shared, pure win, port; (b) restructured nix-arg-building blocks - nix-only,
+   skip
+3. Apply only (a) via `Edit` tool - replace one line in this repo's
+   `wsl_setup.ps1`. Leave (b) alone.
+4. Verify by reading the surrounding code in this repo to confirm the new
+   line slots in cleanly
+5. Commit
+
+## When in doubt
+
+- Read the actual envy-nx file, not just the CHANGELOG entry
+- Skip > break. A missed port can be picked up next time; a broken port
+  costs the user a setup re-run
+- Run the tests. If a ported test fails on this repo's code, that's a
+  signal to fix something - not to drop the test
+- When the layout diverges (envy-nx has `tests/pester/Scopes.Tests.ps1`,
+  this repo doesn't have a scope system), don't reinvent infrastructure to
+  make the test fit - skip the test

--- a/BACKPORT.md
+++ b/BACKPORT.md
@@ -16,9 +16,9 @@ against the rules below.
 ## Last ported through
 
 ```text
-envy-nx commit: <SHA>      # bump on each backport PR; agent reads CHANGELOG entries newer than this
-envy-nx tag:    <TAG>      # nearest released tag for human readability
-ported on:      <YYYY-MM-DD>
+envy-nx commit: c859bba    # bump on each backport PR; agent reads CHANGELOG entries newer than this
+envy-nx tag:    v1.4.0     # nearest released tag for human readability
+ported on:      2026-05-01
 ```
 
 When you finish a backport PR, update all three lines and include the bump in

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@ SHELL := /bin/bash
 # Default target
 .DEFAULT_GOAL := help
 
+# MITM proxy support: use native TLS (OpenSSL) in prek to trust system CA certificates
+export PREK_NATIVE_TLS := 1
+# tell Node.js/npm to trust custom MITM proxy certificates (for prek-managed node hooks)
+CA_CUSTOM := $(wildcard $(HOME)/.config/certs/ca-custom.crt)
+ifdef CA_CUSTOM
+export NODE_EXTRA_CA_CERTS := $(CA_CUSTOM)
+endif
+
 .PHONY: help
 help: ## Show this help message
 	@printf 'Usage: make [target]\n\n'
@@ -18,16 +26,24 @@ upgrade: ## Upgrade prek and hooks versions
 	prek self update
 	prek auto-update
 
+.PHONY: hooks
+hooks: ## List available pre-commit hook IDs
+	@awk '/- id:/ {print "  " $$3}' .pre-commit-config.yaml | sort -u
+
 .PHONY: lint lint-diff lint-all
-lint: ## Run pre-commit hooks for changed files
+lint: ## Run pre-commit hooks for changed files (HOOK=id to run one hook)
 	@printf "🧭 Running pre-commit hooks for changed files...\n\n"
-	git add --all && prek run
-lint-diff: ## Run pre-commit hooks for files changed in this diff
+	git add --all && prek run $(HOOK)
+lint-diff: ## Run pre-commit hooks for files changed in this diff (HOOK=id to run one hook)
 	@printf "🧭 Running pre-commit hooks for files changed in this diff...\n\n"
-	@[ "$$(git branch --show-current)" = "main" ] && printf "⚠️  You are on the main branch. Skipping lint-diff.\n" || prek run --from-ref main --to-ref HEAD
-lint-all: ## Run pre-commit hooks for all files
+	@if [ "$$(git branch --show-current)" = "main" ]; then \
+		printf "⚠️  You are on the main branch. Skipping lint-diff.\n"; \
+	else \
+		git add --all && prek run $(HOOK) --from-ref main --to-ref HEAD; \
+	fi
+lint-all: ## Run pre-commit hooks for all files (HOOK=id to run one hook)
 	@printf "🧭 Running pre-commit hooks for all files...\n\n"
-	prek run --all-files
+	prek run $(HOOK) --all-files
 
 .PHONY: test test-unit test-bats test-pester
 test: test-unit ## Run all unit tests

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,13 @@ lint-diff: ## Run pre-commit hooks for files changed in this diff
 lint-all: ## Run pre-commit hooks for all files
 	@printf "🧭 Running pre-commit hooks for all files...\n\n"
 	prek run --all-files
+
+.PHONY: test test-unit test-bats test-pester
+test: test-unit ## Run all unit tests
+test-unit: test-bats test-pester ## Run bats and Pester unit tests
+test-bats: ## Run bats unit tests
+	@printf "\n\033[95;1m== bats ==\033[0m\n\n"
+	@bats tests/bats/
+test-pester: ## Run Pester unit tests
+	@printf "\n\033[95;1m== Pester ==\033[0m\n\n"
+	@pwsh -nop -c '$$cfg = New-PesterConfiguration; $$cfg.Run.Path = "tests/pester/"; $$cfg.Run.Exit = $$true; $$cfg.Output.Verbosity = "Detailed"; Invoke-Pester -Configuration $$cfg'

--- a/modules/InstallUtils/Functions/common.ps1
+++ b/modules/InstallUtils/Functions/common.ps1
@@ -45,7 +45,7 @@ function Invoke-CommandRetry {
 }
 
 function Join-Str {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'None')]
     [OutputType([string])]
     param (
         [Parameter(Mandatory, ValueFromPipeline = $true)]

--- a/modules/InstallUtils/Functions/git.ps1
+++ b/modules/InstallUtils/Functions/git.ps1
@@ -27,6 +27,12 @@ function Invoke-GhRepoClone {
         $org, $repo = $OrgRepo.Split('/')
         # command for getting the remote url
         $getOrigin = { git config --get remote.origin.url; if (-not $?) { 'https://github.com/' } }
+        # determine clone protocol: prefer SSH if key is configured, fallback to HTTPS
+        $gitProtocol = if (ssh -T git@github.com 2>&1 | Select-String -Quiet 'successfully authenticated') {
+            'git@github.com:'
+        } else {
+            $(Invoke-Command $getOrigin) -replace '(^.+github\.com[:/]).*', '$1'
+        }
         # calculate destination path
         $destPath = Join-Path $Path -ChildPath $repo
     }
@@ -52,16 +58,23 @@ function Invoke-GhRepoClone {
             }
             Pop-Location
         } catch {
-            # determine GitHub protocol used (https/ssl)
-            $gitProtocol = $(Invoke-Command $getOrigin) -replace '(^.+github\.com[:/]).*', '$1'
-            # clone target repository
-            git clone "${gitProtocol}${org}/${repo}.git" "$destPath" --quiet
-            # determine state of cloning the repository
+            # clone target repository - try SSH first, fall back to HTTPS
+            $cloneUrl = "${gitProtocol}${org}/${repo}.git"
+            $cloneErr = $null
+            git clone $cloneUrl "$destPath" --quiet 2>&1 | ForEach-Object { $cloneErr += "$_`n" }
+            if (-not $?) {
+                if ($gitProtocol -eq 'git@github.com:') {
+                    Write-Warning "SSH clone failed, retrying with HTTPS: $($cloneErr?.Trim())"
+                    $cloneUrl = "https://github.com/${org}/${repo}.git"
+                    $cloneErr = $null
+                    git clone $cloneUrl "$destPath" --quiet 2>&1 | ForEach-Object { $cloneErr += "$_`n" }
+                }
+            }
             $status = if ($?) {
                 Write-Verbose "Repository `"$OrgRepo`" cloned successfully."
                 Write-Output 1
             } else {
-                Write-Warning "Cloning of the `"$OrgRepo`" repository failed."
+                Write-Warning "Cloning `"$OrgRepo`" failed ($cloneUrl): $($cloneErr?.Trim())"
                 Write-Output 0
             }
         }
@@ -79,35 +92,59 @@ Function for updating current git branch from remote.
 function Update-GitRepository {
     [CmdletBinding()]
     param ()
-    # perform check if the repository has remote
-    $remote = git remote 2>$null
-    if ($remote) {
-        # fetch updates from remote
-        Write-Verbose "fetching $remote..."
-        for ($i = 1; $i -le 10; $i++) {
-            Write-Verbose "attempt No. $i..."
-            git fetch --tags --prune --prune-tags --force $remote 2>$null
-            if ($?) {
-                $fetched = $true
-                break
-            }
-        }
-        if (-not $fetched) {
-            Write-Warning 'Fetching from remote failed.'
+    # resolve upstream tracking ref in a single call (e.g. "origin/main");
+    # fall back to first remote + current branch when no upstream is configured
+    $upstream = git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>$null
+    if ($upstream) {
+        $remote, $branch = $upstream -split '/', 2
+    } else {
+        $remote = git remote 2>$null | Select-Object -First 1
+        if (-not $remote) {
+            Write-Warning 'Not a git repository.'
             return 0
         }
-        # check if current branch is behind remote
         $branch = git branch --show-current
-        if ((git rev-parse HEAD) -ne (git rev-parse "$remote/$branch")) {
-            Write-Verbose "$branch branch is behind the $remote, performing hard reset"
-            git reset --hard "$remote/$branch"
-            return 2
-        } else {
-            Write-Verbose "$branch branch is up to date"
+        $upstream = "$remote/$branch"
+    }
+
+    # cheap pre-check: `ls-remote` is a single small network round-trip with no local writes.
+    # if the remote tip already matches our tracking ref, the previous fetch is still current
+    # and we can skip the heavy `git fetch --tags --prune --prune-tags --force` (the dominant
+    # IO cost on slow disks - it always rewrites FETCH_HEAD, packed-refs, etc. even on no-op)
+    $remoteSha = ((git ls-remote --heads $remote $branch 2>$null) -split '\s+', 2)[0]
+    $localUpstreamSha = git rev-parse $upstream 2>$null
+    if ($remoteSha -and $localUpstreamSha -and $remoteSha -eq $localUpstreamSha) {
+        if ((git rev-parse HEAD) -eq $localUpstreamSha) {
+            Write-Verbose "$branch branch is up to date (skipped fetch)"
             return 1
         }
-    } else {
-        Write-Warning 'Not a git repository.'
+        Write-Verbose "$branch behind $upstream (skipped fetch, performing hard reset)"
+        git reset --hard $upstream
+        return 2
+    }
+
+    # full fetch path: remote moved, ls-remote was unreachable, or no local tracking ref yet
+    Write-Verbose "fetching $remote..."
+    $fetched = $false
+    for ($i = 1; $i -le 10; $i++) {
+        Write-Verbose "attempt No. $i..."
+        git fetch --tags --prune --prune-tags --force $remote 2>$null
+        if ($?) {
+            $fetched = $true
+            break
+        }
+    }
+    if (-not $fetched) {
+        Write-Warning 'Fetching from remote failed.'
         return 0
     }
+    # single rev-parse for both refs
+    $shas = git rev-parse HEAD $upstream
+    if ($shas[0] -ne $shas[1]) {
+        Write-Verbose "$branch branch is behind the $remote, performing hard reset"
+        git reset --hard $upstream
+        return 2
+    }
+    Write-Verbose "$branch branch is up to date"
+    return 1
 }

--- a/modules/SetupUtils/Functions/common.ps1
+++ b/modules/SetupUtils/Functions/common.ps1
@@ -111,7 +111,7 @@ function ConvertTo-Cfg {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
-        [System.Collections.Specialized.OrderedDictionary]$OrderedDict,
+        [System.Collections.IDictionary]$OrderedDict,
 
         [string]$Path,
 

--- a/modules/SetupUtils/Functions/logs.ps1
+++ b/modules/SetupUtils/Functions/logs.ps1
@@ -113,19 +113,19 @@ function Get-LogLine {
 
             # build the log line to show
             [string]::Join('|',
-                "`e[36m$($ctx.TimeStamp.ToString('yyyy-MM-dd HH:mm:ss'))`e[0m",
+                "`e[36m$($LogContext.TimeStamp.ToString('yyyy-MM-dd HH:mm:ss'))`e[0m",
                 "${lvlColor}${Level}`e[0m",
-                "`e[90m$($ctx.Invocation)`e[0m",
-                "`e[90m$($ctx.Function)`e[0m: $Message"
+                "`e[90m$($LogContext.Invocation)`e[0m",
+                "`e[90m$($LogContext.Function)`e[0m: $Message"
             )
         }
         Write {
             # build the log line to write
             [string]::Join('|',
-                $ctx.TimeStamp.ToString('yyyy-MM-dd HH:mm:ss.fff'),
+                $LogContext.TimeStamp.ToString('yyyy-MM-dd HH:mm:ss.fff'),
                 $Level,
-                $ctx.Invocation,
-                $ctx.Function,
+                $LogContext.Invocation,
+                $LogContext.Function,
                 $Message
             )
         }

--- a/tests/bats/test_fixcertpy_discovery.bats
+++ b/tests/bats/test_fixcertpy_discovery.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# Unit tests for fixcertpy auto-discovery parsing patterns
+# Tests the sed/grep patterns used to extract paths from pip show output.
+# The actual fixcertpy function is tested with explicit paths in test_functions.bats;
+# these tests cover the auto-discovery codepath's parsing logic.
+# shellcheck disable=SC2030,SC2031
+bats_require_minimum_version 1.5.0
+
+# Sample pip show -f certifi output
+CERTIFI_SHOW='Name: certifi
+Version: 2024.2.2
+Summary: Python package for providing Mozilla CA Bundle.
+Home-page: https://github.com/certifi/python-certifi
+Author: Kenneth Reitz
+Location: /home/user/.local/lib/python3.12/site-packages
+Files:
+  certifi/__init__.py
+  certifi/__main__.py
+  certifi/cacert.pem
+  certifi/core.py
+  certifi/py.typed'
+
+# Sample pip show -f pip output (cacert.pem is deeper)
+PIP_SHOW='Name: pip
+Version: 24.0
+Summary: The PyPA recommended tool for installing Python packages.
+Location: /usr/lib/python3/dist-packages
+Files:
+  pip/__init__.py
+  pip/_vendor/certifi/cacert.pem
+  pip/_vendor/certifi/core.py'
+
+# Sample output with no cacert.pem
+NO_CACERT_SHOW='Name: requests
+Version: 2.31.0
+Summary: Python HTTP library
+Location: /home/user/.local/lib/python3.12/site-packages
+Files:
+  requests/__init__.py
+  requests/api.py'
+
+# =============================================================================
+# Location extraction: sed -n 's/^Location: //p'
+# =============================================================================
+
+@test "location extraction: standard certifi output" {
+  run bash -c 'echo "$1" | sed -n "s/^Location: //p"' -- "$CERTIFI_SHOW"
+  [ "$output" = "/home/user/.local/lib/python3.12/site-packages" ]
+}
+
+@test "location extraction: pip output" {
+  run bash -c 'echo "$1" | sed -n "s/^Location: //p"' -- "$PIP_SHOW"
+  [ "$output" = "/usr/lib/python3/dist-packages" ]
+}
+
+@test "location extraction: empty when no Location field" {
+  run bash -c 'echo "Name: foo" | sed -n "s/^Location: //p"'
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# cacert.pem path extraction: grep -oE '[^[:space:]]+cacert\.pem$'
+# =============================================================================
+
+@test "cacert extraction: certifi package" {
+  run bash -c 'echo "$1" | grep -oE "[^[:space:]]+cacert\.pem$"' -- "$CERTIFI_SHOW"
+  [ "$output" = "certifi/cacert.pem" ]
+}
+
+@test "cacert extraction: pip vendored certifi" {
+  run bash -c 'echo "$1" | grep -oE "[^[:space:]]+cacert\.pem$"' -- "$PIP_SHOW"
+  [ "$output" = "pip/_vendor/certifi/cacert.pem" ]
+}
+
+@test "cacert extraction: empty when no cacert.pem" {
+  run bash -c 'echo "$1" | grep -oE "[^[:space:]]+cacert\.pem$"' -- "$NO_CACERT_SHOW"
+  [ -z "$output" ]
+}
+
+# =============================================================================
+# Combined: build full path (Location + cacert)
+# =============================================================================
+
+@test "full path: certifi package" {
+  local location cacert
+  location=$(echo "$CERTIFI_SHOW" | sed -n 's/^Location: //p')
+  cacert=$(echo "$CERTIFI_SHOW" | grep -oE '[^[:space:]]+cacert\.pem$')
+  [ "${location}/${cacert}" = "/home/user/.local/lib/python3.12/site-packages/certifi/cacert.pem" ]
+}
+
+@test "full path: pip vendored certifi" {
+  local location cacert
+  location=$(echo "$PIP_SHOW" | sed -n 's/^Location: //p')
+  cacert=$(echo "$PIP_SHOW" | grep -oE '[^[:space:]]+cacert\.pem$')
+  [ "${location}/${cacert}" = "/usr/lib/python3/dist-packages/pip/_vendor/certifi/cacert.pem" ]
+}
+
+@test "full path: empty cacert yields no path addition" {
+  local location cacert
+  location=$(echo "$NO_CACERT_SHOW" | sed -n 's/^Location: //p')
+  cacert=$(echo "$NO_CACERT_SHOW" | grep -oE '[^[:space:]]+cacert\.pem$' || true)
+  [ -z "$cacert" ]
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+@test "location with spaces in path" {
+  local show='Name: certifi
+Location: /home/user/my projects/venv/lib/python3.12/site-packages
+Files:
+  certifi/cacert.pem'
+  local location
+  location=$(echo "$show" | sed -n 's/^Location: //p')
+  [ "$location" = "/home/user/my projects/venv/lib/python3.12/site-packages" ]
+}
+
+@test "multiple cacert.pem matches picks all" {
+  # grep -oE returns all matches; the function uses only the first one per pip show call
+  local show='Files:
+  certifi/cacert.pem
+  old/certifi/cacert.pem'
+  run bash -c 'echo "$1" | grep -oE "[^[:space:]]+cacert\.pem$"' -- "$show"
+  [ "${lines[0]}" = "certifi/cacert.pem" ]
+  [ "${lines[1]}" = "old/certifi/cacert.pem" ]
+  [ "${#lines[@]}" -eq 2 ]
+}

--- a/tests/bats/test_functions.bats
+++ b/tests/bats/test_functions.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+# Unit tests for .assets/config/bash_cfg/functions.sh
+# Tests PEM parsing, fixcertpy (explicit paths), cert_intercept deduplication.
+# Requires: openssl
+# shellcheck disable=SC2034,SC2154
+bats_require_minimum_version 1.5.0
+
+setup_file() {
+  # skip entire file if openssl is not available
+  command -v openssl &>/dev/null || skip "openssl not available"
+
+  export TEST_DIR="$(mktemp -d)"
+
+  # generate two self-signed test certificates
+  openssl req -x509 -newkey rsa:2048 -keyout "$TEST_DIR/key1.pem" -out "$TEST_DIR/cert1.pem" \
+    -days 1 -nodes -subj "/CN=Test Cert One" 2>/dev/null
+  openssl req -x509 -newkey rsa:2048 -keyout "$TEST_DIR/key2.pem" -out "$TEST_DIR/cert2.pem" \
+    -days 1 -nodes -subj "/CN=Test Cert Two" 2>/dev/null
+
+  # create a multi-cert bundle
+  cat "$TEST_DIR/cert1.pem" "$TEST_DIR/cert2.pem" >"$TEST_DIR/ca-custom.crt"
+
+  # extract serials for verification
+  export SERIAL1="$(openssl x509 -noout -serial <"$TEST_DIR/cert1.pem" | cut -d= -f2)"
+  export SERIAL2="$(openssl x509 -noout -serial <"$TEST_DIR/cert2.pem" | cut -d= -f2)"
+}
+
+teardown_file() {
+  rm -rf "$TEST_DIR"
+}
+
+setup() {
+  command -v openssl &>/dev/null || skip "openssl not available"
+  # shellcheck source=../../.assets/config/bash_cfg/functions.sh
+  source "$BATS_TEST_DIRNAME/../../.assets/config/bash_cfg/functions.sh"
+  # override HOME so cert functions use our test directory
+  export REAL_HOME="$HOME"
+  export HOME="$TEST_DIR"
+}
+
+teardown() {
+  export HOME="$REAL_HOME"
+}
+
+# =============================================================================
+# PEM bundle parsing (the shared pattern used by fixcertpy and cert_intercept)
+# =============================================================================
+
+@test "PEM parsing splits bundle into individual certs" {
+  local cert_pems=()
+  local current_pem=""
+  while IFS= read -r line; do
+    if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+      current_pem="$line"
+    elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+      current_pem+=$'\n'"$line"
+      cert_pems+=("$current_pem")
+      current_pem=""
+    elif [[ -n "$current_pem" ]]; then
+      current_pem+=$'\n'"$line"
+    fi
+  done <"$TEST_DIR/ca-custom.crt"
+
+  [[ ${#cert_pems[@]} -eq 2 ]]
+}
+
+@test "PEM parsing produces valid certificates" {
+  local cert_pems=()
+  local current_pem=""
+  while IFS= read -r line; do
+    if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+      current_pem="$line"
+    elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+      current_pem+=$'\n'"$line"
+      cert_pems+=("$current_pem")
+      current_pem=""
+    elif [[ -n "$current_pem" ]]; then
+      current_pem+=$'\n'"$line"
+    fi
+  done <"$TEST_DIR/ca-custom.crt"
+
+  # each parsed cert should be readable by openssl
+  for pem in "${cert_pems[@]}"; do
+    run openssl x509 -noout -subject <<<"$pem"
+    [[ "$status" -eq 0 ]]
+  done
+}
+
+@test "PEM parsing handles single cert" {
+  local cert_pems=()
+  local current_pem=""
+  while IFS= read -r line; do
+    if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+      current_pem="$line"
+    elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+      current_pem+=$'\n'"$line"
+      cert_pems+=("$current_pem")
+      current_pem=""
+    elif [[ -n "$current_pem" ]]; then
+      current_pem+=$'\n'"$line"
+    fi
+  done <"$TEST_DIR/cert1.pem"
+
+  [[ ${#cert_pems[@]} -eq 1 ]]
+}
+
+@test "PEM parsing handles empty file" {
+  touch "$TEST_DIR/empty.crt"
+  local cert_pems=()
+  local current_pem=""
+  while IFS= read -r line; do
+    if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
+      current_pem="$line"
+    elif [[ "$line" == "-----END CERTIFICATE-----" ]]; then
+      current_pem+=$'\n'"$line"
+      cert_pems+=("$current_pem")
+      current_pem=""
+    elif [[ -n "$current_pem" ]]; then
+      current_pem+=$'\n'"$line"
+    fi
+  done <"$TEST_DIR/empty.crt"
+
+  [[ ${#cert_pems[@]} -eq 0 ]]
+}
+
+# =============================================================================
+# fixcertpy - with explicit paths (no pip/venv discovery)
+# =============================================================================
+
+@test "fixcertpy appends certs to explicit cacert.pem path" {
+  # set up fake cert bundle and target
+  mkdir -p "$TEST_DIR/.config/certs"
+  cp "$TEST_DIR/ca-custom.crt" "$TEST_DIR/.config/certs/ca-custom.crt"
+  # create a minimal target cacert.pem
+  echo "# existing bundle" >"$TEST_DIR/cacert.pem"
+
+  run fixcertpy "$TEST_DIR/cacert.pem"
+
+  # target should now contain both serials
+  grep -qw "$SERIAL1" "$TEST_DIR/cacert.pem"
+  grep -qw "$SERIAL2" "$TEST_DIR/cacert.pem"
+}
+
+@test "fixcertpy does not duplicate certs on re-run" {
+  mkdir -p "$TEST_DIR/.config/certs"
+  cp "$TEST_DIR/ca-custom.crt" "$TEST_DIR/.config/certs/ca-custom.crt"
+  echo "# existing bundle" >"$TEST_DIR/cacert2.pem"
+
+  # run twice
+  fixcertpy "$TEST_DIR/cacert2.pem" 2>/dev/null
+  local size_after_first
+  size_after_first=$(wc -c <"$TEST_DIR/cacert2.pem")
+
+  fixcertpy "$TEST_DIR/cacert2.pem" 2>/dev/null
+  local size_after_second
+  size_after_second=$(wc -c <"$TEST_DIR/cacert2.pem")
+
+  # file should not grow on second run
+  [[ "$size_after_first" -eq "$size_after_second" ]]
+}
+
+@test "fixcertpy reports no certs when bundle is missing" {
+  # ensure no cert bundle exists
+  rm -f "$TEST_DIR/.config/certs/ca-custom.crt"
+
+  run fixcertpy "$TEST_DIR/some_cacert.pem"
+  # should return 0 (no certs to add is not an error)
+  [[ "$status" -eq 0 ]]
+}
+
+@test "fixcertpy skips nonexistent target paths" {
+  mkdir -p "$TEST_DIR/.config/certs"
+  cp "$TEST_DIR/ca-custom.crt" "$TEST_DIR/.config/certs/ca-custom.crt"
+
+  # pass a path that doesn't exist
+  run fixcertpy "/nonexistent/path/cacert.pem"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"no certifi/cacert.pem bundles found"* ]]
+}
+
+# =============================================================================
+# cert_intercept deduplication - string-based serial tracking
+# =============================================================================
+
+@test "serial dedup string correctly tracks added serials" {
+  local _existing_serials=" "
+
+  # simulate adding serials
+  _existing_serials+="$SERIAL1 "
+  [[ " $_existing_serials " == *" $SERIAL1 "* ]]
+
+  # serial2 should not be present yet
+  [[ " $_existing_serials " != *" $SERIAL2 "* ]]
+
+  # add serial2
+  _existing_serials+="$SERIAL2 "
+  [[ " $_existing_serials " == *" $SERIAL2 "* ]]
+}
+
+@test "serial dedup string does not match partial serials" {
+  local _existing_serials=" ABC123 "
+
+  # should not match partial
+  [[ " $_existing_serials " != *" ABC "* ]]
+  [[ " $_existing_serials " != *" 123 "* ]]
+  # should match full
+  [[ " $_existing_serials " == *" ABC123 "* ]]
+}
+
+@test "cert_intercept returns 1 when openssl is missing" {
+  # shadow openssl
+  type() { return 1; }
+  run ! cert_intercept
+  [[ "$output" == *"openssl"*"required"* ]]
+}

--- a/tests/hooks/align_tables.py
+++ b/tests/hooks/align_tables.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Auto-align markdown table columns.
+
+Ensures all pipe characters in each table are at the same
+column position across all rows (MD060 compliance).
+
+Usage:
+    python3 -m tests.hooks.align_tables docs/*.md
+"""
+
+import sys
+import unicodedata
+
+
+def _display_width(text: str) -> int:
+    """Return the monospace display width of *text*.
+
+    Wide characters (most emoji, CJK) count as 2 columns.
+    Zero-width characters (combining marks, variation selectors, ZWJ) count as 0.
+    A base character followed by VS16 (U+FE0F) is forced to width 2 (emoji presentation).
+    """
+    width = 0
+    chars = list(text)
+    for i, ch in enumerate(chars):
+        cat = unicodedata.category(ch)
+        # zero-width: combining marks (Mn/Mc/Me), format chars (Cf) like ZWJ/VS16
+        if cat.startswith("M") or cat == "Cf":
+            continue
+        # check if next char is VS16 (emoji presentation selector)
+        has_vs16 = i + 1 < len(chars) and chars[i + 1] == "️"
+        eaw = unicodedata.east_asian_width(ch)
+        if eaw in ("W", "F") or has_vs16:
+            width += 2
+        else:
+            width += 1
+    return width
+
+
+def _pad(text: str, target_width: int) -> str:
+    """Pad *text* with spaces so its display width equals *target_width*."""
+    return text + " " * (target_width - _display_width(text))
+
+
+def align_table(lines):
+    """Align all pipes in a markdown table."""
+    rows = []
+    for line in lines:
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        rows.append(cells)
+
+    if len(rows) < 2:
+        return lines
+
+    num_cols = len(rows[0])
+
+    # Find max display width per column (skip separator row)
+    widths = [0] * num_cols
+    for i, row in enumerate(rows):
+        if i == 1:
+            continue
+        for j, cell in enumerate(row):
+            if j < num_cols:
+                widths[j] = max(widths[j], _display_width(cell))
+
+    # Rebuild rows with aligned pipes
+    result = []
+    for i, row in enumerate(rows):
+        if i == 1:
+            parts = ["| " + "-" * widths[j] + " " for j in range(num_cols)]
+        else:
+            parts = [
+                "| " + _pad(row[j] if j < len(row) else "", widths[j]) + " "
+                for j in range(num_cols)
+            ]
+        result.append("".join(parts) + "|")
+    return result
+
+
+def process_file(path):
+    """Process a single markdown file. Return True if changes were made."""
+    with open(path) as f:
+        original = f.read()
+
+    lines = original.splitlines()
+    result = []
+    table_buf = []
+    in_table = False
+    in_code_block = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code_block = not in_code_block
+        is_table = (
+            not in_code_block and stripped.startswith("|") and "|" in stripped[1:]
+        )
+        if is_table:
+            table_buf.append(line)
+            in_table = True
+        else:
+            if in_table:
+                result.extend(align_table(table_buf))
+                table_buf = []
+                in_table = False
+            result.append(line)
+
+    if table_buf:
+        result.extend(align_table(table_buf))
+
+    new_content = "\n".join(result) + "\n"
+    if new_content != original:
+        with open(path, "w") as f:
+            f.write(new_content)
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file.md> [file2.md ...]")
+        sys.exit(1)
+
+    for path in sys.argv[1:]:
+        if process_file(path):
+            print(f"Aligned: {path}")
+        else:
+            print(f"OK: {path}")

--- a/tests/hooks/check_zsh_compat.py
+++ b/tests/hooks/check_zsh_compat.py
@@ -1,0 +1,208 @@
+"""
+Check shell scripts for zsh compatibility.
+
+This hook is rule-driven and scope-agnostic: pre-commit-config.yaml decides
+which files to feed in (`files:` regex), the hook applies all rules to
+whatever it receives. Inline suppression: append `# zsh-ok` to a line.
+
+Rules catch patterns that break or behave incorrectly under zsh:
+
+- Bare function definitions (`name() {`) - zsh expands aliases during
+  parsing, so `function name() {` is required to suppress expansion.
+- Numeric array subscripts - zsh arrays are 1-based (bash is 0-based).
+- For-loops over unquoted globs - zsh's `nomatch` option aborts the
+  command on no-match instead of leaving the literal pattern; use
+  `find ... | while IFS= read -r f` instead.
+- Bash-only variables/builtins (BASH_SOURCE, compgen, COMP_WORDS, etc.)
+  that must be inside a `[ -n "$BASH_VERSION" ]` guard.
+
+Optionally runs `zsh -n` (syntax check) when zsh is available.
+
+# :example
+python3 -m tests.hooks.check_zsh_compat .assets/config/bash_cfg/aliases_git.sh
+python3 -m tests.hooks.check_zsh_compat .assets/config/bash_cfg/functions.sh
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Rules: each is (compiled regex, human description, guarded)
+#   guarded=False  → always flag (code should be rewritten)
+#   guarded=True   → skip when inside a BASH_VERSION guard block
+# ---------------------------------------------------------------------------
+
+
+class Rule(NamedTuple):
+    pattern: re.Pattern[str]
+    description: str
+    guarded: bool = False
+
+
+RULES: tuple[Rule, ...] = (
+    # -- always flag (rewrite needed) ---------------------------------------
+    Rule(
+        re.compile(r"^\s*(?!function\s)[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)\s*\{"),
+        "bare function definition - use `function name() {` "
+        "to prevent zsh alias expansion conflicts",
+    ),
+    Rule(
+        re.compile(r"\$\{?[a-zA-Z_]\w*\[\s*[0-9]"),
+        "numeric array subscript - zsh arrays are 1-based; "
+        "avoid indexed arrays or guard with BASH_VERSION",
+        guarded=True,
+    ),
+    Rule(
+        re.compile(r"^\s*for\s+\w+\s+in\s+[^#\n]*\*"),
+        "for-loop with unquoted glob - zsh's `nomatch` option aborts "
+        "the command on no-match (`no matches found: ...`) instead of "
+        'leaving the literal pattern for a `[ -f "$f" ]` guard. '
+        "Use `find ... | while IFS= read -r f` instead",
+    ),
+    # -- guarded (need BASH_VERSION check) ----------------------------------
+    Rule(
+        re.compile(r"\bBASH_SOURCE\b"),
+        "BASH_SOURCE does not exist in zsh - "
+        'guard with [ -n "$BASH_VERSION" ] or add fallback',
+        guarded=True,
+    ),
+    Rule(
+        re.compile(r"\bBASH_REMATCH\b"),
+        "BASH_REMATCH does not exist in zsh (use $match) - "
+        'guard with [ -n "$BASH_VERSION" ]',
+        guarded=True,
+    ),
+    Rule(
+        re.compile(r"\bcompgen\b"),
+        'compgen is a bash-only builtin - guard with [ -n "$BASH_VERSION" ]',
+        guarded=True,
+    ),
+    Rule(
+        re.compile(r"\bcomplete\s+-[FW]"),
+        'complete is a bash-only builtin - guard with [ -n "$BASH_VERSION" ]',
+        guarded=True,
+    ),
+    Rule(
+        re.compile(r"\b(COMP_WORDS|COMP_CWORD|COMPREPLY)\b"),
+        'bash-only completion variable - guard with [ -n "$BASH_VERSION" ]',
+        guarded=True,
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Guard detection patterns
+# ---------------------------------------------------------------------------
+_RE_IF = re.compile(r"^\s*(if|elif)\b")
+_RE_IF_BASH = re.compile(r"BASH_VERSION")
+_RE_FI = re.compile(r"^\s*fi\b")
+
+
+def check_file(filepath: Path) -> list[str]:
+    """Check a single file for zsh compatibility violations."""
+    problems: list[str] = []
+    try:
+        lines = filepath.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return problems
+
+    in_colon_heredoc = False
+    if_nesting = 0
+    bash_guard_depth = 0
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.lstrip()
+
+        # track : '...' comment blocks (used for runnable examples)
+        if not in_colon_heredoc and stripped.startswith(": '"):
+            in_colon_heredoc = True
+            continue
+        if in_colon_heredoc:
+            if stripped.rstrip() == "'":
+                in_colon_heredoc = False
+            continue
+
+        # skip comments and lines with inline suppression
+        if stripped.startswith("#"):
+            continue
+        if "# zsh-ok" in line:
+            continue
+
+        # track if/fi nesting for BASH_VERSION guard detection
+        if _RE_IF.match(stripped):
+            if_nesting += 1
+            if _RE_IF_BASH.search(stripped):
+                bash_guard_depth = if_nesting
+        elif _RE_FI.match(stripped):
+            if if_nesting == bash_guard_depth:
+                bash_guard_depth = 0
+            if_nesting -= 1
+
+        in_guard = bash_guard_depth > 0
+
+        for rule in RULES:
+            if rule.guarded and in_guard:
+                continue
+            if rule.pattern.search(line):
+                rel = filepath.as_posix()
+                problems.append(f"{rel}:{lineno}: {rule.description}")
+    return problems
+
+
+def _zsh_syntax_check(filepath: Path) -> list[str]:
+    """Run zsh -n syntax check on a file. Returns problems or empty list."""
+    try:
+        result = subprocess.run(
+            ["zsh", "-n", str(filepath)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            rel = filepath.as_posix()
+            return [f"{rel}: zsh -n: {result.stderr.strip()}"]
+    except (FileNotFoundError, subprocess.TimeoutExpired):  # fmt: skip
+        pass
+    return []
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        return 0
+
+    repo_root = Path(__file__).resolve().parents[2]
+    targets = [Path(f).resolve() for f in argv if Path(f).is_file()]
+    if not targets:
+        return 0
+
+    problems: list[str] = []
+    has_zsh = shutil.which("zsh") is not None
+
+    for filepath in targets:
+        # make paths relative for readable output
+        try:
+            rel = filepath.relative_to(repo_root)
+        except ValueError:
+            rel = filepath
+        check_path = rel if rel.exists() else filepath
+        problems.extend(check_file(check_path))
+        if has_zsh:
+            problems.extend(_zsh_syntax_check(check_path))
+
+    if problems:
+        print("Zsh compatibility violations:", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            f"\n{len(problems)} violation(s) found.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/hooks/gremlins.py
+++ b/tests/hooks/gremlins.py
@@ -1,5 +1,12 @@
 """
-Scan staged text files for unwanted Unicode characters and fail if found.
+Scan staged text files for unwanted Unicode characters.
+
+Auto-fixes characters with obvious ASCII replacements (dashes, smart quotes,
+fancy spaces, etc.) and reports any remaining unfixable gremlins.
+
+When auto-fixes are applied the hook prints what changed and exits 0;
+pre-commit detects the modified file and blocks the commit so the user
+can review, re-stage, and commit again.
 
 # :example
 python3 -m tests.hooks.gremlins wsl/wsl_setup.ps1
@@ -9,65 +16,48 @@ import os
 import sys
 import unicodedata
 from collections.abc import Iterable
-from typing import Tuple
 
-FORBIDDEN_CHARS: Tuple[str, ...] = (
-    # Zero-width / joiner
-    "\u200b",  # U+200B ZERO WIDTH SPACE
-    "\u200c",  # U+200C ZERO WIDTH NON-JOINER
-    "\u200d",  # U+200D ZERO WIDTH JOINER
-    # Spaces / breaks
-    "\u00a0",  # U+00A0 NO-BREAK SPACE
-    "\u202f",  # U+202F NARROW NO-BREAK SPACE
-    "\u2009",  # U+2009 THIN SPACE
-    "\u200a",  # U+200A HAIR SPACE
-    # Control / formatting
-    "\u000c",  # U+000C FORM FEED
-    "\u00ad",  # U+00AD SOFT HYPHEN
-    # Dashes / hyphens
-    "\u2013",  # U+2013 EN DASH
-    "\u2014",  # U+2014 EM DASH
-    "\u2010",  # U+2010 HYPHEN
-    # Quotes / punctuation that look like ASCII
-    "\u2018",  # U+2018 LEFT SINGLE QUOTATION MARK
-    "\u2019",  # U+2019 RIGHT SINGLE QUOTATION MARK
-    "\u201c",  # U+201C LEFT DOUBLE QUOTATION MARK
-    "\u201d",  # U+201D RIGHT DOUBLE QUOTATION MARK
-    "\u2026",  # U+2026 HORIZONTAL ELLIPSIS
-    # Misc common problematic characters
-    "\u00b7",  # U+00B7 MIDDLE DOT
+# Characters with a clear ASCII replacement -- auto-fixed in place.
+AUTO_FIX: dict[str, str] = {
+    # Dashes / hyphens -> ASCII hyphen-minus
+    "\u2010": "-",  # HYPHEN
+    "\u2013": "-",  # EN DASH
+    "\u2014": "-",  # EM DASH
+    # Fancy spaces -> regular space
+    "\u00a0": " ",  # NO-BREAK SPACE
+    "\u202f": " ",  # NARROW NO-BREAK SPACE
+    "\u2009": " ",  # THIN SPACE
+    "\u200a": " ",  # HAIR SPACE
+    # Smart quotes -> ASCII quotes
+    "\u2018": "'",  # LEFT SINGLE QUOTATION MARK
+    "\u2019": "'",  # RIGHT SINGLE QUOTATION MARK
+    "\u201c": '"',  # LEFT DOUBLE QUOTATION MARK
+    "\u201d": '"',  # RIGHT DOUBLE QUOTATION MARK
+    # Ellipsis -> three dots
+    "\u2026": "...",  # HORIZONTAL ELLIPSIS
+    # Invisible / zero-width -> remove
+    "\u200b": "",  # ZERO WIDTH SPACE
+    "\u200c": "",  # ZERO WIDTH NON-JOINER
+    "\u200d": "",  # ZERO WIDTH JOINER
+    "\u00ad": "",  # SOFT HYPHEN
+    "\u000c": "",  # FORM FEED
+}
+
+# Characters that cannot be auto-fixed -- always reported for manual review.
+REPORT_ONLY: tuple[str, ...] = (
+    "\u00b7",  # MIDDLE DOT
 )
 
+ALL_FORBIDDEN = set(AUTO_FIX) | set(REPORT_ONLY)
 
-def find_forbidden_in_text(content: str, filename: str) -> list[str]:
-    """
-    Scan the given text for forbidden Unicode characters and report their locations.
 
-    Parameters
-    ----------
-    content : str
-        The text content to scan for forbidden characters.
-    filename : str
-        The name of the file being scanned, used in the report output.
-
-    Returns
-    -------
-    list[str]
-        A list of human-readable report strings. Each string is formatted as:
-        "filename:lineno: contains <Unicode name> (<Unicode codepoint>)"
-        For example: "example.py:10: contains ZERO WIDTH SPACE (U+200B)"
-    """
-    reports: list[str] = []
-    for lineno, line in enumerate(content.splitlines(), start=1):
-        for ch in FORBIDDEN_CHARS:
-            if ch in line:
-                code = f"U+{ord(ch):04X}"
-                try:
-                    name = unicodedata.name(ch)
-                except ValueError:
-                    name = "<unknown>"
-                reports.append(f"{filename}:{lineno}: contains {name} ({code})")
-    return reports
+def _char_label(ch: str) -> str:
+    code = f"U+{ord(ch):04X}"
+    try:
+        name = unicodedata.name(ch)
+    except ValueError:
+        name = "<unknown>"
+    return f"{name} ({code})"
 
 
 def is_text_file(path: str) -> bool:
@@ -75,41 +65,70 @@ def is_text_file(path: str) -> bool:
     try:
         with open(path, "rb") as fh:
             chunk = fh.read(4096)
-            # if NUL bytes present it's likely binary
             return b"\x00" not in chunk
     except OSError:
         return False
 
 
+def fix_and_report(path: str) -> tuple[list[str], list[str]]:
+    """Auto-fix what we can, report what we cannot.
+
+    Returns (fixed_reports, unfixable_reports).
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            content = fh.read()
+    except OSError:
+        return [], []
+
+    fixed_chars: set[str] = set()
+    new_content = content
+    for ch, replacement in AUTO_FIX.items():
+        if ch in new_content:
+            fixed_chars.add(ch)
+            new_content = new_content.replace(ch, replacement)
+
+    if fixed_chars:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(new_content)
+
+    fixed_reports = []
+    if fixed_chars:
+        labels = ", ".join(sorted(_char_label(ch) for ch in fixed_chars))
+        fixed_reports.append(f"{path}: fixed {labels}")
+
+    unfixable_reports = []
+    for lineno, line in enumerate(new_content.splitlines(), start=1):
+        for ch in REPORT_ONLY:
+            if ch in line:
+                unfixable_reports.append(f"{path}:{lineno}: contains {_char_label(ch)}")
+
+    return fixed_reports, unfixable_reports
+
+
 def check_gremlins(argv: Iterable[str]) -> int:
-    """
-    Check a list of text files for forbidden Unicode characters.
-
-    Args:
-        argv (Iterable[str]): An iterable of file path strings to check.
-
-    Returns:
-        int: Returns 0 if no forbidden characters are found in any file,
-        or 1 if at least one forbidden character is found.
-    """
     files = list(argv)
-    problems: list[str] = []
+    all_fixed: list[str] = []
+    all_unfixable: list[str] = []
+
     for path in files:
         if not os.path.exists(path) or not is_text_file(path):
             continue
-        try:
-            with open(path, "r", encoding="utf-8", errors="replace") as fh:
-                content = fh.read()
-        except OSError:
-            continue
-        problems.extend(find_forbidden_in_text(content, path))
+        fixed, unfixable = fix_and_report(path)
+        all_fixed.extend(fixed)
+        all_unfixable.extend(unfixable)
 
-    if problems:
-        print("Gremlin characters found:", file=sys.stderr)
-        for p in problems:
-            print(p, file=sys.stderr)
-        print("Remove or replace gremlin characters", file=sys.stderr)
+    if all_fixed:
+        print("Gremlin characters auto-fixed:", file=sys.stderr)
+        for r in all_fixed:
+            print(f"  {r}", file=sys.stderr)
+
+    if all_unfixable:
+        print("Gremlin characters found (manual fix required):", file=sys.stderr)
+        for r in all_unfixable:
+            print(f"  {r}", file=sys.stderr)
         return 1
+
     return 0
 
 

--- a/tests/hooks/run_bats.py
+++ b/tests/hooks/run_bats.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Run bats tests for changed files.
+
+Scans tests/bats/*.bats for `source` directives to build a mapping of which
+source files are covered by which test files. When any covered source file
+(or a .bats file itself) is staged, runs the relevant tests.
+
+# :example
+python3 -m tests.hooks.run_bats
+# :run with explicit file list (as pre-commit passes them)
+python3 -m tests.hooks.run_bats .assets/config/bash_cfg/functions.sh
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BATS_DIR = REPO_ROOT / "tests" / "bats"
+
+
+def build_source_map() -> dict[str, list[Path]]:
+    """Parse .bats files and return {relative_source_path: [bats_files]}."""
+    source_to_tests: dict[str, list[Path]] = {}
+
+    if not BATS_DIR.is_dir():
+        return source_to_tests
+
+    # match: source "path" or source 'path' with optional $BATS_TEST_DIRNAME/ prefix
+    source_re = re.compile(
+        r'^\s*source\s+["\']'
+        r"(?:\$BATS_TEST_DIRNAME/)?"
+        r'(.+?)["\']',
+    )
+
+    for bats_file in sorted(BATS_DIR.glob("*.bats")):
+        bats_rel = bats_file.relative_to(REPO_ROOT).as_posix()
+
+        # the .bats file itself is always in scope
+        source_to_tests.setdefault(bats_rel, []).append(bats_file)
+
+        for line in bats_file.read_text().splitlines():
+            m = source_re.match(line)
+            if not m:
+                continue
+
+            raw_path = m.group(1)
+            # resolve relative to the bats file directory
+            resolved = (BATS_DIR / raw_path).resolve()
+            try:
+                rel = resolved.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                continue
+
+            source_to_tests.setdefault(rel, []).append(bats_file)
+
+    return source_to_tests
+
+
+def main(argv: list[str] | None = None) -> int:
+    if not shutil.which("bats"):
+        print("bats not found, skipping tests", file=sys.stderr)
+        return 0
+
+    # files passed by pre-commit (or CLI)
+    changed_files = set(argv or [])
+
+    source_map = build_source_map()
+    if not source_map:
+        return 0
+
+    # collect bats files to run
+    to_run: set[Path] = set()
+    for changed in changed_files:
+        # normalize to posix-style relative path
+        normalized = Path(changed).as_posix()
+        if normalized in source_map:
+            to_run.update(source_map[normalized])
+
+    if not to_run:
+        return 0
+
+    cmd = ["bats"] + sorted(str(f) for f in to_run)
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/hooks/run_pester.py
+++ b/tests/hooks/run_pester.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Run Pester tests for changed PowerShell files.
+
+Scans tests/pester/*.Tests.ps1 for dot-source directives to build a mapping
+of which source files are covered by which test files. When any covered source
+file (or a .Tests.ps1 file itself) is staged, runs the relevant tests.
+
+# :example
+python3 -m tests.hooks.run_pester
+# :run with explicit file list (as pre-commit passes them)
+python3 -m tests.hooks.run_pester modules/SetupUtils/Functions/common.ps1
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PESTER_DIR = REPO_ROOT / "tests" / "pester"
+
+
+def build_source_map() -> dict[str, list[Path]]:
+    """Parse .Tests.ps1 files and return {relative_source_path: [test_files]}."""
+    source_to_tests: dict[str, list[Path]] = {}
+
+    if not PESTER_DIR.is_dir():
+        return source_to_tests
+
+    # match: . $PSScriptRoot/../../path/to/file.ps1
+    # or: . "$PSScriptRoot/../../path/to/file.ps1"
+    source_re = re.compile(
+        r"^\s*\.\s+"
+        r'["\']?\$PSScriptRoot/'
+        r"(.+?\.ps1)"
+        r'["\']?\s*$',
+    )
+
+    for test_file in sorted(PESTER_DIR.glob("*.Tests.ps1")):
+        test_rel = test_file.relative_to(REPO_ROOT).as_posix()
+
+        # the test file itself is always in scope
+        source_to_tests.setdefault(test_rel, []).append(test_file)
+
+        for line in test_file.read_text().splitlines():
+            m = source_re.match(line)
+            if not m:
+                continue
+
+            raw_path = m.group(1)
+            # resolve relative to the pester test directory
+            resolved = (PESTER_DIR / raw_path).resolve()
+            try:
+                rel = resolved.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                continue
+
+            source_to_tests.setdefault(rel, []).append(test_file)
+
+    return source_to_tests
+
+
+def main(argv: list[str] | None = None) -> int:
+    if not shutil.which("pwsh"):
+        print("pwsh not found, skipping Pester tests", file=sys.stderr)
+        return 0
+
+    # files passed by pre-commit (or CLI)
+    changed_files = set(argv or [])
+
+    source_map = build_source_map()
+    if not source_map:
+        return 0
+
+    # collect test files to run
+    to_run: set[Path] = set()
+    for changed in changed_files:
+        normalized = Path(changed).as_posix()
+        if normalized in source_map:
+            to_run.update(source_map[normalized])
+
+    if not to_run:
+        return 0
+
+    # build Pester invocation with specific test files
+    test_paths = sorted(str(f) for f in to_run)
+    paths_arg = ", ".join(f"'{p}'" for p in test_paths)
+    # Use Configuration to enable exit-on-failure without XML report conflicts
+    pester_cmd = (
+        "$cfg = New-PesterConfiguration; "
+        f"$cfg.Run.Path = @({paths_arg}); "
+        "$cfg.Run.Exit = $true; "
+        "$cfg.Output.Verbosity = 'Detailed'; "
+        "Invoke-Pester -Configuration $cfg"
+    )
+
+    pwsh_path = shutil.which("pwsh") or "pwsh"
+    result = subprocess.run([pwsh_path, "-nop", "-c", pester_cmd])
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/pester/ConvertCfg.Tests.ps1
+++ b/tests/pester/ConvertCfg.Tests.ps1
@@ -1,0 +1,186 @@
+#Requires -Modules Pester
+# Unit tests for ConvertFrom-Cfg and ConvertTo-Cfg in SetupUtils module
+
+BeforeAll {
+    . $PSScriptRoot/../../modules/SetupUtils/Functions/common.ps1
+}
+
+Describe 'ConvertFrom-Cfg' {
+    It 'parses section with key-value pairs' {
+        $input = @(
+            '[section1]'
+            'key1 = value1'
+            'key2 = value2'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['key1'] | Should -Be 'value1'
+        $result['section1']['key2'] | Should -Be 'value2'
+    }
+
+    It 'parses multiple sections' {
+        $input = @(
+            '[section1]'
+            'key1 = value1'
+            '[section2]'
+            'key2 = value2'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result.Keys | Should -HaveCount 2
+        $result['section1']['key1'] | Should -Be 'value1'
+        $result['section2']['key2'] | Should -Be 'value2'
+    }
+
+    It 'preserves header comments in __header__ key' {
+        $input = @(
+            '# This is a header comment'
+            '# Another header line'
+            '[section1]'
+            'key = value'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result.Contains('__header__') | Should -BeTrue
+        $result['__header__'] | Should -BeLike '*header comment*'
+    }
+
+    It 'preserves comments within sections' {
+        $input = @(
+            '[section1]'
+            '# inline comment'
+            'key = value'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['Comment1'] | Should -Be '# inline comment'
+        $result['section1']['key'] | Should -Be 'value'
+    }
+
+    It 'ignores non-comment lines before first section' {
+        $input = @(
+            'stray line without section'
+            '[section1]'
+            'key = value'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['key'] | Should -Be 'value'
+        $result.Contains('__header__') | Should -BeFalse
+    }
+
+    It 'handles empty value' {
+        $input = @(
+            '[section1]'
+            'key ='
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['key'] | Should -Be ''
+    }
+
+    It 'trims whitespace from values' {
+        $input = @(
+            '[section1]'
+            'key =   spaced value   '
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['key'] | Should -Be 'spaced value'
+    }
+
+    It 'handles semicolon comments' {
+        $input = @(
+            '[section1]'
+            '; semicolon comment'
+            'key = value'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['Comment1'] | Should -Be '; semicolon comment'
+    }
+
+    It 'resets comment counter per section' {
+        $input = @(
+            '[section1]'
+            '# comment in s1'
+            '[section2]'
+            '# comment in s2'
+        )
+        $result = $input | ConvertFrom-Cfg
+        $result['section1']['Comment1'] | Should -Be '# comment in s1'
+        $result['section2']['Comment1'] | Should -Be '# comment in s2'
+    }
+
+    It 'returns empty dict for empty input' {
+        $result = @() | ConvertFrom-Cfg
+        $result.Keys | Should -HaveCount 0
+    }
+}
+
+Describe 'ConvertTo-Cfg' {
+    It 'serializes ordered dictionary to cfg string' {
+        $dict = [ordered]@{
+            section1 = [ordered]@{
+                key1 = 'value1'
+                key2 = 'value2'
+            }
+        }
+        $result = $dict | ConvertTo-Cfg
+        $result | Should -Match '\[section1\]'
+        $result | Should -Match 'key1 = value1'
+        $result | Should -Match 'key2 = value2'
+    }
+
+    It 'restores header comments' {
+        $dict = [ordered]@{
+            '__header__' = '# header line'
+            section1     = [ordered]@{ key = 'value' }
+        }
+        $result = $dict | ConvertTo-Cfg
+        $result | Should -Match '# header line'
+    }
+
+    It 'serializes comment keys back as comments' {
+        $dict = [ordered]@{
+            section1 = [ordered]@{
+                Comment1 = '# a comment'
+                key      = 'value'
+            }
+        }
+        $result = $dict | ConvertTo-Cfg
+        $result | Should -Match '# a comment'
+        $result | Should -Not -Match 'Comment1'
+    }
+
+    It 'handles LineFeed switch' {
+        $dict = [ordered]@{
+            section1 = [ordered]@{ key = 'value' }
+        }
+        $result = $dict | ConvertTo-Cfg -LineFeed
+        $result | Should -Not -Match "`r`n"
+    }
+
+    It 'accepts a non-ordered IDictionary (hashtable)' {
+        # PR A widened the parameter type from OrderedDictionary to IDictionary;
+        # this asserts a plain hashtable now pipes in cleanly.
+        $dict = @{
+            section1 = @{ key = 'value' }
+        }
+        { $dict | ConvertTo-Cfg } | Should -Not -Throw
+    }
+}
+
+Describe 'ConvertFrom-Cfg / ConvertTo-Cfg roundtrip' {
+    It 'preserves content through roundtrip' {
+        $original = @(
+            '# file header'
+            '[core]'
+            'autocrlf = true'
+            '# a comment'
+            'editor = vim'
+            '[remote "origin"]'
+            'url = https://github.com/foo/bar.git'
+        )
+        $parsed = $original | ConvertFrom-Cfg
+        $serialized = $parsed | ConvertTo-Cfg -LineFeed
+
+        # re-parse
+        $reparsed = $serialized.Split("`n") | ConvertFrom-Cfg
+        $reparsed['core']['autocrlf'] | Should -Be 'true'
+        $reparsed['core']['editor'] | Should -Be 'vim'
+        $reparsed['remote "origin"']['url'] | Should -Be 'https://github.com/foo/bar.git'
+    }
+}

--- a/tests/pester/ConvertPEM.Tests.ps1
+++ b/tests/pester/ConvertPEM.Tests.ps1
@@ -1,0 +1,119 @@
+#Requires -Modules Pester
+# Unit tests for ConvertFrom-PEM and ConvertTo-PEM in SetupUtils module
+
+BeforeAll {
+    . $PSScriptRoot/../../modules/SetupUtils/Functions/certs.ps1
+}
+
+Describe 'ConvertFrom-PEM' {
+    BeforeAll {
+        # generate a self-signed test certificate
+        $cert = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=Pester Test Cert',
+            [System.Security.Cryptography.RSA]::Create(2048),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        ).CreateSelfSigned(
+            [DateTimeOffset]::UtcNow,
+            [DateTimeOffset]::UtcNow.AddDays(1)
+        )
+        $base64 = [Convert]::ToBase64String($cert.RawData)
+        # build PEM string with 64-char line wrapping
+        $pemLines = @('-----BEGIN CERTIFICATE-----')
+        for ($i = 0; $i -lt $base64.Length; $i += 64) {
+            $length = [Math]::Min(64, $base64.Length - $i)
+            $pemLines += $base64.Substring($i, $length)
+        }
+        $pemLines += '-----END CERTIFICATE-----'
+        $Script:testPem = $pemLines -join "`n"
+        $Script:testCert = $cert
+    }
+
+    It 'parses a single PEM certificate from string' {
+        $result = @($Script:testPem | ConvertFrom-PEM)
+        $result | Should -HaveCount 1
+        $result[0].Subject | Should -BeLike '*Pester Test Cert*'
+    }
+
+    It 'parses multiple PEM certificates from string' {
+        $multiPem = "$($Script:testPem)`n$($Script:testPem)"
+        # ConvertFrom-PEM deduplicates via HashSet, so two identical certs yield one
+        $result = @($multiPem | ConvertFrom-PEM)
+        $result | Should -HaveCount 1
+    }
+
+    It 'handles empty string input gracefully' {
+        # Empty string triggers a non-terminating parameter binding error.
+        # The function still returns no results.
+        $result = @('' | ConvertFrom-PEM -ErrorAction SilentlyContinue)
+        $result | Should -HaveCount 0
+    }
+
+    It 'handles string with no PEM markers' {
+        $result = @('not a certificate' | ConvertFrom-PEM)
+        $result | Should -HaveCount 0
+    }
+}
+
+Describe 'ConvertTo-PEM' {
+    BeforeAll {
+        # generate a self-signed test certificate
+        $Script:testCert = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=Pester PEM Test',
+            [System.Security.Cryptography.RSA]::Create(2048),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        ).CreateSelfSigned(
+            [DateTimeOffset]::UtcNow,
+            [DateTimeOffset]::UtcNow.AddDays(1)
+        )
+    }
+
+    It 'converts certificate to PEM string' {
+        $result = @($Script:testCert | ConvertTo-PEM)
+        $result | Should -HaveCount 1
+        $result[0] | Should -Match 'BEGIN CERTIFICATE'
+        $result[0] | Should -Match 'END CERTIFICATE'
+    }
+
+    It 'adds header with -AddHeader' {
+        $result = @($Script:testCert | ConvertTo-PEM -AddHeader)
+        $result[0] | Should -Match '# Subject:.*Pester PEM Test'
+        $result[0] | Should -Match '# Serial:'
+        $result[0] | Should -Match '# Issuer:'
+    }
+
+    It 'wraps base64 at 64 chars' {
+        $result = @($Script:testCert | ConvertTo-PEM)
+        $pemContent = $result[0]
+        $lines = $pemContent.Split("`n") | Where-Object { $_ -and $_ -notmatch '^-' -and $_ -notmatch '^#' }
+        # all lines except the last should be exactly 64 chars
+        foreach ($line in $lines[0..($lines.Count - 2)]) {
+            $line.Length | Should -Be 64
+        }
+        # last line should be <= 64 chars
+        $lines[-1].Length | Should -BeLessOrEqual 64
+    }
+}
+
+Describe 'ConvertFrom-PEM / ConvertTo-PEM roundtrip' {
+    BeforeAll {
+        $Script:testCert = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=Pester Roundtrip',
+            [System.Security.Cryptography.RSA]::Create(2048),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        ).CreateSelfSigned(
+            [DateTimeOffset]::UtcNow,
+            [DateTimeOffset]::UtcNow.AddDays(1)
+        )
+    }
+
+    It 'preserves certificate through roundtrip' {
+        $pem = @($Script:testCert | ConvertTo-PEM)[0]
+        $restored = @($pem | ConvertFrom-PEM)
+        $restored | Should -HaveCount 1
+        $restored[0].Subject | Should -BeLike '*Pester Roundtrip*'
+        $restored[0].Thumbprint | Should -Be $Script:testCert.Thumbprint
+    }
+}

--- a/tests/pester/GetLogLine.Tests.ps1
+++ b/tests/pester/GetLogLine.Tests.ps1
@@ -1,0 +1,71 @@
+#Requires -Modules Pester
+# Unit tests for Get-LogLine in SetupUtils module
+
+BeforeAll {
+    . $PSScriptRoot/../../modules/SetupUtils/Functions/logs.ps1
+}
+
+Describe 'Get-LogLine' {
+    BeforeAll {
+        $Script:testContext = [PSCustomObject]@{
+            TimeStamp  = [datetime]::new(2025, 6, 15, 10, 30, 45, 123)
+            Invocation = 'test.ps1:42'
+            Function   = 'Test-Function():10'
+            IsVerbose  = $false
+            IsDebug    = $false
+        }
+    }
+
+    Context 'Show line type' {
+        It 'contains timestamp, level, invocation, and function' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'hello world' -Level 'INFO' -LineType 'Show'
+            $result | Should -Match '2025-06-15 10:30:45'
+            $result | Should -Match 'INFO'
+            $result | Should -Match 'test\.ps1:42'
+            $result | Should -Match 'hello world'
+        }
+
+        It 'applies correct color for ERROR level' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'fail' -Level 'ERROR' -LineType 'Show'
+            $result | Should -Match '91m.*ERROR'
+        }
+
+        It 'applies correct color for WARNING level' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'warn' -Level 'WARNING' -LineType 'Show'
+            $result | Should -Match '93m.*WARNING'
+        }
+
+        It 'applies correct color for VERBOSE level' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'info' -Level 'VERBOSE' -LineType 'Show'
+            $result | Should -Match '96m.*VERBOSE'
+        }
+
+        It 'applies correct color for DEBUG level' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'dbg' -Level 'DEBUG' -LineType 'Show'
+            $result | Should -Match '35m.*DEBUG'
+        }
+    }
+
+    Context 'Write line type' {
+        It 'produces pipe-delimited plain text' {
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'log entry' -Level 'INFO' -LineType 'Write'
+            $parts = $result.Split('|')
+            $parts | Should -HaveCount 5
+            $parts[0] | Should -Match '2025-06-15 10:30:45\.123'
+            $parts[1] | Should -Be 'INFO'
+            $parts[2] | Should -Be 'test.ps1:42'
+            $parts[3] | Should -Be 'Test-Function():10'
+            $parts[4] | Should -Be 'log entry'
+        }
+    }
+
+    Context 'LogContext parameter is used correctly' {
+        It 'works without $ctx in caller scope' {
+            # Verify that Get-LogLine uses the $LogContext parameter directly
+            # and does not depend on $ctx being in the caller scope.
+            Remove-Variable -Name ctx -ErrorAction SilentlyContinue
+            $result = Get-LogLine -LogContext $Script:testContext -Message 'test' -Level 'INFO' -LineType 'Write'
+            $result | Should -Match 'INFO'
+        }
+    }
+}

--- a/tests/pester/InvokeCommandRetry.Tests.ps1
+++ b/tests/pester/InvokeCommandRetry.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Modules Pester
+# Unit tests for Invoke-CommandRetry in InstallUtils module
+
+BeforeAll {
+    . $PSScriptRoot/../../modules/InstallUtils/Functions/common.ps1
+}
+
+Describe 'Invoke-CommandRetry' {
+    It 'succeeds on first attempt' {
+        $Script:retryCounter = 0
+        Invoke-CommandRetry -Command { $Script:retryCounter++ } -MaxRetries 3
+        $Script:retryCounter | Should -Be 1
+    }
+
+    It 'stops after MaxRetries on persistent error' {
+        $Script:retryCounter = 0
+        Invoke-CommandRetry -Command {
+            $Script:retryCounter++
+            $ex = [System.IO.IOException]::new('persistent error')
+            throw $ex
+        } -MaxRetries 3 -ErrorAction SilentlyContinue -Verbose:$false
+        $Script:retryCounter | Should -BeLessOrEqual 3
+    }
+
+    It 'rethrows non-retryable exceptions' {
+        {
+            Invoke-CommandRetry -Command {
+                throw [InvalidOperationException]::new('bad')
+            } -MaxRetries 2 -ErrorAction Stop
+        } | Should -Throw
+    }
+
+    It 'executes command successfully when no error' {
+        $Script:retryResult = $null
+        Invoke-CommandRetry -Command { $Script:retryResult = 'success' }
+        $Script:retryResult | Should -Be 'success'
+    }
+}

--- a/tests/pester/JoinStr.Tests.ps1
+++ b/tests/pester/JoinStr.Tests.ps1
@@ -1,0 +1,43 @@
+#Requires -Modules Pester
+# Unit tests for Join-Str in InstallUtils module
+
+BeforeAll {
+    . $PSScriptRoot/../../modules/InstallUtils/Functions/common.ps1
+}
+
+Describe 'Join-Str' {
+    It 'wraps with single quotes' {
+        $result = 'a', 'b' | Join-Str -SingleQuote
+        $result | Should -Be "'a' 'b'"
+    }
+
+    It 'wraps with double quotes' {
+        $result = 'a', 'b' | Join-Str -DoubleQuote
+        $result | Should -Be '"a" "b"'
+    }
+
+    It 'combines separator and single quotes' {
+        $result = 'x', 'y' | Join-Str -Separator ',' -SingleQuote
+        $result | Should -Be "'x','y'"
+    }
+
+    It 'combines separator and double quotes' {
+        $result = 'x', 'y' | Join-Str -Separator ',' -DoubleQuote
+        $result | Should -Be '"x","y"'
+    }
+
+    It 'handles single item with single quote' {
+        $result = 'only' | Join-Str -SingleQuote
+        $result | Should -Be "'only'"
+    }
+
+    It 'handles pipeline array with single quote' {
+        $result = @('one', 'two', 'three') | Join-Str -Separator '-' -SingleQuote
+        $result | Should -Be "'one'-'two'-'three'"
+    }
+
+    It 'joins without quotes when neither switch is specified' {
+        $result = 'a', 'b' | Join-Str
+        $result | Should -Be 'a b'
+    }
+}

--- a/wsl/wsl_certs_add.ps1
+++ b/wsl/wsl_certs_add.ps1
@@ -142,6 +142,26 @@ process {
     # copy certificates to the distro specific cert directory and install them
     $cmnd = "mkdir -p $($crt.path) && install -m 0644 $($tmpFolder.Name)/*.crt $($crt.path) && $($crt.cmnd)"
     wsl -d $Distro -u root --exec bash -c $cmnd
+
+    # write ca-custom.crt with MITM proxy certificates only
+    $bundleBuilder = [System.Text.StringBuilder]::new()
+    foreach ($cert in $certSet) {
+        $bundleBuilder.Append(($cert | ConvertTo-PEM -AddHeader)) | Out-Null
+    }
+    $bundlePath = [IO.Path]::Combine($tmpFolder, 'ca-custom.crt')
+    [IO.File]::WriteAllText($bundlePath, $bundleBuilder.ToString().Replace("`r`n", "`n"))
+    $userCertDir = '~/.config/certs'
+    $cmndCustom = "mkdir -p $userCertDir && install -m 0644 $($tmpFolder.Name)/ca-custom.crt $userCertDir/"
+    wsl -d $Distro --exec bash -c $cmndCustom
+
+    # create ca-bundle.crt - symlink to system CA bundle (which already includes custom certs)
+    $cmndBundle = @(
+        "cd $userCertDir"
+        'for f in /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt'
+        'do if [ -f "$f" ]; then ln -sf "$f" ca-bundle.crt; break; fi'
+        'done'
+    ) -join '; '
+    wsl -d $Distro --exec bash -c $cmndBundle
 }
 
 clean {

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -243,8 +243,7 @@ begin {
         Show-LogContext 'getting GitHub authentication config from the default distro'
         $defDistro = $lxss.Where({ $_.Default }).Name
         if ($defDistro -ne $Distro) {
-            $cmdArgs = @('-u', (wsl.exe --distribution $defDistro -- id -un), '-k')
-            $gh_cfg = wsl.exe --distribution $defDistro --user root --exec .assets/provision/setup_gh_https.sh @cmdArgs
+            $gh_cfg = wsl.exe --distribution $defDistro -- cat "`$HOME/.config/gh/hosts.yml" 2>$null
         }
         # get installed distro details
         $lxss = Get-WslDistro -FromRegistry | Where-Object Name -EQ $Distro

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -500,6 +500,19 @@ process {
                 $sshStatus.sshKey = 'missing'
             }
         }
+
+        # *whitelist Windows-mount repo paths as git safe.directory
+        # On /mnt/c/ paths the .git dir owner UID (from the Windows side)
+        # doesn't match the WSL user's UID, so git refuses operations with a
+        # "dubious ownership" warning. Two globs cover the typical layouts:
+        #   ~/source/repos/<repo>           - flat
+        #   ~/source/repos/<org>/<repo>     - org-scoped (the convention here)
+        # Per-user (writes ~/.gitconfig in the WSL user's home), idempotent.
+        $mntRepos = "/mnt/c/Users/$env:USERNAME/source/repos"
+        foreach ($glob in "$mntRepos/*", "$mntRepos/*/*") {
+            $cmnd = "git config --global --get-all safe.directory 2>/dev/null | grep -qFx '$glob' || git config --global --add safe.directory '$glob'"
+            wsl.exe --distribution $Distro --exec bash -c $cmnd | Out-Null
+        }
         #endregion
 
         #region install scopes


### PR DESCRIPTION
## Summary

Backports parallel-functionality improvements from [`envy-nx`](https://github.com/szymonos/envy-nx) (the cross-platform Nix descendant in rapid development) and lays down infrastructure to make future backports straightforward.

- 6 code commits: bug fixes, perf improvements, user-scope cert bundle, POSIX guard, WSL `safe.directory` wiring
- 5 tooling commits: bats/Pester unit tests, two CI workflows, `BACKPORT.md` playbook, shfmt + editorconfig + Makefile QoL

## Commits

| #  | SHA       | Subject                                                                  |
| -- | --------- | ------------------------------------------------------------------------ |
| 1  | `76b7dfd` | fix: backport bug fixes and small improvements from envy-nx              |
| 2  | `b3a2b49` | perf: speed up Update-GitRepository and improve Invoke-GhRepoClone       |
| 3  | `4ca5363` | feat(certs): user-scope cert bundle for tools that bypass system trust   |
| 4  | `67c8cce` | test: port unit tests, runners, and zsh-compat hook from envy-nx         |
| 5  | `58649ce` | fix: POSIX-guard bash-syntax /etc/profile.d/ files                       |
| 6  | `cf3ba30` | fix(wsl): register Windows-mount repo paths as git safe.directory        |
| 7  | `e126af8` | ci: add unit tests and labeled integration test workflows                |
| 8  | `f53b87d` | docs: add BACKPORT.md, align-tables hook, gremlins auto-fix              |
| 9  | `84e98fc` | ci: add shfmt pre-commit hook + reformat existing shell scripts          |
| 10 | `ba21a57` | chore(make): port MITM cert env, HOOK=id selector, and hooks list        |
| 11 | `247e751` | fix(editorconfig): include bats and bash in 2-space indent group         |

## Bug classes caught (by ports or by tests added in this PR)

- `Get-LogLine` `$ctx`-leak (PR A) - new Pester test asserts it works without `$ctx` in caller scope
- `Join-Str` missing `DefaultParameterSetName` - caught when running ported test against this repo's code
- `fix_gcloud_certs.sh` missing `;;` before `esac` - caught by shfmt
- `/etc/profile.d/{aliases_git,functions}.sh` failing under dash - caught by `dash -c '. <file>'` probe in `test_linux.yml`

## Validation done locally

- `make lint` and `make lint-all` both green (13 hooks)
- `make test` green: 22 bats + 42 Pester
- `dash -c '. <file>'` clean for all 5 `/etc/profile.d/` files
- All shell config files defined functions correctly under bash login shell

## Test plan

- [ ] CI: `Unit Tests` workflow passes (bats + Pester on every PR)
- [ ] CI: `Linux Integration Test` passes (Docker build + dash-source verification - fired by `test:integration` label, added below)
- [ ] CI: `Preflight Checks` passes (pre-commit hooks)
- [ ] Manual: re-run `wsl/wsl_setup.ps1 <distro>` against an existing distro and verify:
  - `git config --global --get-all safe.directory` includes `/mnt/c/Users/.../source/repos/*` patterns
  - `/etc/profile.d/{aliases_git,functions}.sh` source cleanly under `dash -c '. <file>'`
  - `~/.config/certs/ca-custom.crt` is populated when `-AddCertificate` flag was used; cert env vars present in user's bash login shell (`echo \$NODE_EXTRA_CA_CERTS`)
- [ ] Manual: from inside the same distro, run `~/source/repos/szymonos/envy-nx/nix/setup.sh` and confirm the Determinate Nix installer's `sh -lc` self-test no longer fails on `aliases_git.sh` parsing

## Documented follow-ups (not in this PR)

- Pester tests for `Update-GitRepository` / `Invoke-GhRepoClone` (commit 2 has no unit coverage)
- Bats tests for `setup_profile_user.sh` cert env-var wiring
- Auto-detect MITM proxy in `wsl_setup.ps1` and call `wsl_certs_add.ps1` automatically (Phase 2 - new functionality)
- Add `Dockerfile.alpine` to `test_linux.yml` matrix for distro coverage
- Optional: `validate_docs_words.py` + cspell hook for markdown spellcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)