### PR TITLE
fix(wsl): ssh-probe guard + harden Linux integration test auth

### DIFF
--- a/.assets/docker/Dockerfile
+++ b/.assets/docker/Dockerfile
@@ -3,6 +3,12 @@ FROM ubuntu:24.04
 # avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
+# optional GitHub token build-arg. forwarded to linux_setup.sh below so the
+# get_gh_release_latest helper in source.sh can authenticate against
+# api.github.com - shared CI runner IPs routinely exhaust the 60/hr public
+# rate limit. CI passes secrets.GITHUB_TOKEN; local builds work without it.
+ARG GITHUB_TOKEN=""
+
 # copy the entire .assets folder into the container
 COPY .assets /home/ubuntu/source/lss/.assets
 COPY modules /home/ubuntu/source/lss/modules
@@ -15,8 +21,9 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/ubuntu-nopasswd \
     # change ownership to the ubuntu user
     && chown -R ubuntu:ubuntu /home/ubuntu/source \
-    # setup the container for the ubuntu user
-    && su - ubuntu -c 'cd "$HOME/source/lss" && .assets/scripts/linux_setup.sh --skip_gh_auth true --scope "pwsh" --omp_theme base' \
+    # setup the container for the ubuntu user. su -c clears env, so inject
+    # GITHUB_TOKEN as a command-prefix env var (the build-arg expands here).
+    && su - ubuntu -c 'cd "$HOME/source/lss" && GITHUB_TOKEN='"'$GITHUB_TOKEN'"' .assets/scripts/linux_setup.sh --skip_gh_auth true --scope "pwsh" --omp_theme base' \
     #
     # clean up
     && apt-get autoremove -y \

--- a/.assets/provision/source.sh
+++ b/.assets/provision/source.sh
@@ -195,11 +195,13 @@ get_gh_release_latest() {
     return 1
   fi
 
-  # try to retrieve gh-cli token
+  # try to retrieve a token: prefer gh CLI auth (interactive use), fall back to
+  # the GITHUB_TOKEN env var (CI / containerized installs - avoids the public
+  # 60/hr api.github.com rate limit on shared runner IPs).
   if [ -x /usr/bin/gh ]; then
-    # get the token from the gh command
     token="$(gh auth token 2>/dev/null)"
   fi
+  [ -z "$token" ] && token="${GITHUB_TOKEN:-}"
 
   # calculate the API URI
   api_uri="https://api.github.com/repos/$owner/$repo/releases"
@@ -340,9 +342,15 @@ install_github_release_user() {
   # set binary_name to gh_repo if not provided
   [ -z "$binary_name" ] && binary_name="$gh_repo"
 
-  # check for GITHUB_TOKEN environment variable (should start with 'ghp_' or 'gho_' and be ~40 chars)
+  # check for GITHUB_TOKEN environment variable. accepts the documented prefixes:
+  #   ghp_  personal access token (classic)
+  #   gho_  OAuth token
+  #   ghu_  user-to-server (GitHub App)
+  #   ghs_  server-to-server (the auto-provided GITHUB_TOKEN inside GitHub Actions)
+  #   ghr_  refresh token
+  #   github_pat_  fine-grained personal access token
   auth_header=""
-  if [ -n "$GITHUB_TOKEN" ] && echo "$GITHUB_TOKEN" | grep -qE "^gh[po]_" && [ ${#GITHUB_TOKEN} -ge 36 ]; then
+  if [ -n "$GITHUB_TOKEN" ] && echo "$GITHUB_TOKEN" | grep -qE "^(gh[a-z]_|github_pat_)" && [ ${#GITHUB_TOKEN} -ge 36 ]; then
     auth_header="-H \"Authorization: Bearer $GITHUB_TOKEN\""
   fi
 

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -47,6 +47,13 @@ jobs:
           load: true
           tags: lss-test:latest
           push: false
+          # forward the auto-provided runner token so get_gh_release_latest
+          # in source.sh can authenticate to api.github.com - shared GHA
+          # runner IPs routinely exhaust the 60/hr unauthenticated quota,
+          # which surfaces as "API rate limit exceeded" during oh-my-posh
+          # release lookup.
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       # ---- verification (continue-on-error so summary shows full picture) ----
       - name: Verify pwsh on PATH

--- a/modules/InstallUtils/Functions/git.ps1
+++ b/modules/InstallUtils/Functions/git.ps1
@@ -27,8 +27,10 @@ function Invoke-GhRepoClone {
         $org, $repo = $OrgRepo.Split('/')
         # command for getting the remote url
         $getOrigin = { git config --get remote.origin.url; if (-not $?) { 'https://github.com/' } }
-        # determine clone protocol: prefer SSH if key is configured, fallback to HTTPS
-        $gitProtocol = if (ssh -T git@github.com 2>&1 | Select-String -Quiet 'successfully authenticated') {
+        # determine clone protocol: prefer SSH if key is configured, fallback to HTTPS.
+        # the Get-Command guard matters on Windows PowerShell hosts (e.g. wsl_setup.ps1) where
+        # OpenSSH may not be on PATH; without it the bare `ssh` call throws under ErrorAction=Stop.
+        $gitProtocol = if ((Get-Command ssh -ErrorAction SilentlyContinue) -and (ssh -T git@github.com 2>&1 | Select-String -Quiet 'successfully authenticated')) {
             'git@github.com:'
         } else {
             $(Invoke-Command $getOrigin) -replace '(^.+github\.com[:/]).*', '$1'


### PR DESCRIPTION
## Summary

Two coordinated fixes on this branch:

### 1. Bug fix: `Invoke-GhRepoClone` ssh-probe guard for Windows hosts (`dfb5943`)

The SSH-first probe added in #246 calls bare `ssh -T git@github.com` from `Invoke-GhRepoClone`'s begin block. With `$ErrorActionPreference = 'Stop'` and Windows PowerShell hosts where OpenSSH isn't on PATH, that throws and aborts `wsl_setup.ps1` mid-`pwsh` provisioning at line 618 (`Invoke-GhRepoClone -OrgRepo 'szymonos/ps-modules'`).

Fix: wrap the probe in `Get-Command ssh -ErrorAction SilentlyContinue` so the function silently falls back to HTTPS on hosts without ssh - matching pre-#246 behavior on Windows while keeping SSH preference on Linux/macOS hosts (where envy-nx normally runs and where this code path was originally validated).

### 2. CI infra: harden Linux integration test against api.github.com rate limit (`97ddcdc`)

The first attempt at this PR's integration test failed with "API rate limit exceeded" during oh-my-posh release lookup ([log](https://github.com/szymonos/linux-setup-scripts/actions/runs/25245136703/job/74028000767?pr=247)). This is a pre-existing flake unrelated to the WSL fix - the Docker build calls `api.github.com` unauthenticated, and shared GitHub Actions runner IPs routinely exhaust the 60/hr public quota.

Three coordinated changes:

- `.assets/docker/Dockerfile`: accept `ARG GITHUB_TOKEN`, propagate inline into the `su -c` invocation (`su -c` clears env, so prefix-style env-var injection is the cleanest path).
- `.github/workflows/test_linux.yml`: pass `build-args: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}` to the build-push step.
- `.assets/provision/source.sh`:
  - `get_gh_release_latest`: fall back from `gh auth token` to `${GITHUB_TOKEN:-}` so containerized runs without `gh` auth still authenticate.
  - `install_github_release_user`: broaden the prefix regex from `^gh[po]_` to `^(gh[a-z]_|github_pat_)` so it accepts the `ghs_` server-to-server token Actions auto-provides (the previous regex only matched `ghp_`/`gho_`).

Local Docker builds without `--build-arg GITHUB_TOKEN` remain functional (var stays empty, behavior matches pre-fix). The token does not leak beyond the runner since the test image uses `push: false`.

## Test plan

- [x] `pwsh` parse-check on `modules/InstallUtils/Functions/git.ps1`
- [x] `make lint` clean
- [x] `make test` - 22 bats / 42 Pester, all green
- [x] Manual quoting trace verifying `su -c` arg expands `$GITHUB_TOKEN` from the build-arg while preserving deferred `$HOME` expansion
- [ ] Linux integration test (label `test:integration` re-attached)
- [ ] Manual: re-run failing `wsl_setup.ps1` flow on a Windows host without OpenSSH installed - the `Invoke-GhRepoClone -OrgRepo 'szymonos/ps-modules'` call should now succeed via HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)