### PR TITLE
fix(wsl): enumerate concrete repo paths for git safe.directory

### DIFF
--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -504,14 +504,33 @@ process {
         # *whitelist Windows-mount repo paths as git safe.directory
         # On /mnt/c/ paths the .git dir owner UID (from the Windows side)
         # doesn't match the WSL user's UID, so git refuses operations with a
-        # "dubious ownership" warning. Two globs cover the typical layouts:
+        # "dubious ownership" warning. safe.directory only matches literal
+        # paths (no shell globs - the only special value is `*` for "trust
+        # everything", which is too broad). Enumerate concrete repo dirs on
+        # the Windows host (fast - no WSL/host roundtrips per dir) and pass
+        # each as a separate entry. Covers both common layouts:
         #   ~/source/repos/<repo>           - flat
-        #   ~/source/repos/<org>/<repo>     - org-scoped (the convention here)
+        #   ~/source/repos/<org>/<repo>     - org-scoped
         # Per-user (writes ~/.gitconfig in the WSL user's home), idempotent.
-        $mntRepos = "/mnt/c/Users/$env:USERNAME/source/repos"
-        foreach ($glob in "$mntRepos/*", "$mntRepos/*/*") {
-            $cmnd = "git config --global --get-all safe.directory 2>/dev/null | grep -qFx '$glob' || git config --global --add safe.directory '$glob'"
-            wsl.exe --distribution $Distro --exec bash -c $cmnd | Out-Null
+        $reposRoot = Join-Path $env:USERPROFILE 'source\repos'
+        if (Test-Path $reposRoot -PathType Container) {
+            $candidates = @(
+                Get-ChildItem -Path $reposRoot -Directory -ErrorAction SilentlyContinue
+                Get-ChildItem -Path $reposRoot -Directory -ErrorAction SilentlyContinue |
+                    ForEach-Object { Get-ChildItem -Path $_.FullName -Directory -ErrorAction SilentlyContinue }
+            )
+            $wslPaths = $candidates |
+                Where-Object { Test-Path (Join-Path $_.FullName '.git') } |
+                ForEach-Object {
+                    # C:\Users\foo\... -> /mnt/c/Users/foo/...
+                    $w = $_.FullName
+                    "/mnt/$([char]::ToLower($w[0]))$($w.Substring(2).Replace('\', '/'))"
+                }
+            if ($wslPaths) {
+                $pathsArg = ($wslPaths | ForEach-Object { "'" + $_.Replace("'", "'\''") + "'" }) -join ' '
+                $bashScript = 'existing=$(git config --global --get-all safe.directory 2>/dev/null); for p in ' + $pathsArg + '; do printf %s "$existing" | grep -qFx "$p" || git config --global --add safe.directory "$p"; done'
+                wsl.exe --distribution $Distro --exec bash -c $bashScript | Out-Null
+            }
         }
         #endregion
 


### PR DESCRIPTION
## Summary

Follow-up on review feedback on #246. The \`safe.directory\` block added there used shell-style globs (\`/mnt/c/.../source/repos/*\` and \`*/* \`), but git's \`safe.directory\` does **not** honor shell globs — it matches literal paths only. The single special value \`*\` means \"trust everything,\" which is too broad. Result: the entries appeared in \`~/.gitconfig\` but did NOT actually suppress the \"dubious ownership\" warning on Windows-mount repos.

## Approach (per @szymonos's suggestion)

Enumerate concrete repo directories on the **Windows host** rather than calling into WSL — the host-side enumeration is fast (no per-directory WSL/Windows filesystem roundtrips), and \`safe.directory\` needs literal paths anyway:

1. \`Get-ChildItem -Directory\` two levels deep under \`\$env:USERPROFILE\\source\\repos\` (covers flat \`repos/<repo>\` and org-scoped \`repos/<org>/<repo>\` layouts)
2. Filter to dirs that contain a \`.git\` subdir — keeps the entry list bounded to actual repos
3. Translate each Windows path to its \`/mnt/c/...\` form (drive letter detected from the actual path, not hard-coded \`c\`)
4. Pass all paths in a single \`wsl.exe --exec bash -c\` invocation that adds any missing entries

## Other improvements bundled

- \`\$env:USERPROFILE\` instead of \`/mnt/c/Users/\$env:USERNAME\` so the home dir resolves correctly when the Windows username contains \`.\` or non-ASCII (common in corporate AD setups where \`\$env:USERNAME\` is \`firstname.lastname.N\` but the home dir might be a truncated/munged variant)
- Drive letter detected from the path — works for source trees on \`D:\\\` etc.
- Single bash invocation instead of one per glob entry

## Test plan

- [x] \`pwsh\` parse-check
- [x] \`make lint\` clean
- [ ] Manual on Windows host: run \`wsl/wsl_setup.ps1 <distro>\`, verify \`git config --global --get-all safe.directory\` inside the distro lists the concrete repo paths, and \`git -C /mnt/c/Users/<you>/source/repos/<some>/<repo> status\` no longer prints the \"dubious ownership\" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)