### PR TITLE
fix(provision): install pwsh user profile after modules; Az on Linux

### DIFF
--- a/.assets/scripts/linux_setup.sh
+++ b/.assets/scripts/linux_setup.sh
@@ -207,8 +207,6 @@ for sc in "${scope_arr[@]}"; do
     sudo .assets/provision/install_pwsh.sh >/dev/null
     printf "\e[96msetting up profile for all users...\e[0m\n"
     sudo .assets/provision/setup_profile_allusers.ps1 -UserName $user
-    printf "\e[96msetting up profile for current user...\e[0m\n"
-    .assets/provision/setup_profile_user.ps1
     ;;
   python)
     printf "\e[96minstalling python tools...\e[0m\n"
@@ -272,6 +270,26 @@ if [ -f /usr/bin/pwsh ]; then
     rm -rf "$HOME/.local/share/powershell/Modules/$module"
     cp -rf "modules/$module" "$HOME/.local/share/powershell/Modules/"
   done
+  # setup current user profile after modules are installed, so completers gated on
+  # module functions (e.g. Register-MakeCompleter in do-unix) resolve
+  printf "\e[96msetting up pwsh profile for current user...\e[0m\n"
+  .assets/provision/setup_profile_user.ps1
+
+  # install PowerShell Az modules required by do-az; runs after setup_profile_user.ps1
+  # so PSGallery is trusted, and after do-common is installed for Invoke-CommandRetry
+  if grep -qw 'az' <<<$scope; then
+    printf "\e[3;32mCurrentUser\e[23m : Az, Az.ResourceGraph\e[0m\n"
+    pwsh -nop -c "
+      if (-not (Get-Module -ListAvailable 'Az')) {
+        Write-Host 'installing Az...'
+        Invoke-CommandRetry { Install-PSResource Az -WarningAction SilentlyContinue -ErrorAction Stop }
+      }
+      if (-not (Get-Module -ListAvailable 'Az.ResourceGraph')) {
+        Write-Host 'installing Az.ResourceGraph...'
+        Invoke-CommandRetry { Install-PSResource Az.ResourceGraph -ErrorAction Stop }
+      }
+    "
+  fi
 fi
 
 # restore working directory

--- a/modules/aliases-git/Functions/alias.ps1
+++ b/modules/aliases-git/Functions/alias.ps1
@@ -241,7 +241,9 @@ function gcv {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose' @PSBoundParameters
@@ -256,7 +258,9 @@ function gc! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --amend' @PSBoundParameters
@@ -271,7 +275,9 @@ function gca {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all' @PSBoundParameters
@@ -286,13 +292,16 @@ function gcap {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gca @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gac {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -304,13 +313,16 @@ function gac {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcv -Xargs $Xargs @PSBoundParameters
+    gcv -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacp {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -322,13 +334,16 @@ function gacp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gac @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gca! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -340,7 +355,9 @@ function gca! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --amend' @PSBoundParameters
@@ -355,13 +372,16 @@ function gac! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gca! -Xargs $Xargs @PSBoundParameters
+    gca! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcam {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -373,7 +393,9 @@ function gcam {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --all -m' @PSBoundParameters
@@ -388,13 +410,16 @@ function gcamp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcam @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacm {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -406,13 +431,16 @@ function gacm {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcmsg -Xargs $Xargs @PSBoundParameters
+    gcmsg -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacmp {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -424,13 +452,16 @@ function gacmp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gacm @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcan! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -442,7 +473,9 @@ function gcan! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --no-edit --amend' @PSBoundParameters
@@ -457,13 +490,16 @@ function gcanp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcan! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcempty {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -475,7 +511,9 @@ function gcempty {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand 'git commit --allow-empty -m' @PSBoundParameters
@@ -490,13 +528,16 @@ function gacn! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcn! -Xargs $Xargs @PSBoundParameters
+    gcn! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacnp! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -508,13 +549,16 @@ function gacnp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gacn! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcns! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -526,7 +570,9 @@ function gcns! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --signoff --no-edit --amend' @PSBoundParameters
@@ -541,7 +587,9 @@ function gcans! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --signoff --no-edit --amend' @PSBoundParameters
@@ -556,13 +604,16 @@ function gacns! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcns! -Xargs $Xargs @PSBoundParameters
+    gcns! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcmsg {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -574,7 +625,9 @@ function gcmsg {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit -m' @PSBoundParameters
@@ -589,13 +642,16 @@ function gcmsgp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcmsg @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcn! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -607,7 +663,9 @@ function gcn! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --no-edit --amend' @PSBoundParameters
@@ -622,13 +680,16 @@ function gcnp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcn! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcsm {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -640,7 +701,9 @@ function gcsm {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --signoff -m' @PSBoundParameters
@@ -1554,7 +1617,9 @@ function gpush {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push' @PSBoundParameters
@@ -1569,7 +1634,9 @@ function gpush! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --force-with-lease' @PSBoundParameters
@@ -1584,7 +1651,9 @@ function gpushdr {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --dry-run' @PSBoundParameters
@@ -1603,12 +1672,16 @@ function gpushoat {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     if ($remote = @(git remote)[0]) {
         # calculate command string
-        $cmnd = "git push $remote --all && git push $remote --tags"
+        $nv = $NoVerify ? ' --no-verify' : ''
+        $cmnd = "git push $remote --all$nv && git push $remote --tags$nv"
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # run command
         Invoke-WriteExecCommand -Command $cmnd @PSBoundParameters
     } else {
@@ -1625,7 +1698,9 @@ function gpushsup {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command "git push --set-upstream origin $(Get-GitCurrentBranch)" @PSBoundParameters
@@ -1640,7 +1715,9 @@ function gpusht {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --tags' @PSBoundParameters
@@ -1655,7 +1732,9 @@ function gpusht! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --tags --force' @PSBoundParameters
@@ -1670,7 +1749,9 @@ function gpushv {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --verbose' @PSBoundParameters

--- a/modules/aliases-git/Functions/helper.ps1
+++ b/modules/aliases-git/Functions/helper.ps1
@@ -59,15 +59,18 @@ function gbdo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
     if ($remote = @(git remote)[0]) {
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git branch --delete $Branch")
-        $commands.Add("git push --delete $remote $Branch")
+        $commands.Add("git push --delete $remote $Branch$($NoVerify ? ' --no-verify' : '')")
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
     } else {
         Write-Host 'fatal: Remote repository not set.'
         return
@@ -92,15 +95,18 @@ function gbdo! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
     if ($remote = @(git remote)[0]) {
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git branch -D $Branch")
-        $commands.Add("git push --delete $remote $Branch")
+        $commands.Add("git push --delete $remote $Branch$($NoVerify ? ' --no-verify' : '')")
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
     } else {
         Write-Host 'fatal: Remote repository not set.'
         return
@@ -153,7 +159,9 @@ function gpushd {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     if ($remote = @(git remote)[0]) {
@@ -210,7 +218,9 @@ function gmgo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
@@ -219,7 +229,9 @@ function gmgo {
         $currentBranch = git branch --show-current
         # resolve provided branch
         $resolvedBranch = Get-GitResolvedBranch $Branch
+        $nv = $NoVerify ? ' --no-verify' : ''
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # build list of commands to execute
         Invoke-WriteExecCommand -Command "git fetch $remote --prune" @PSBoundParameters
         if ($currentBranch -ne $resolvedBranch) {
@@ -227,7 +239,7 @@ function gmgo {
         }
         Invoke-WriteExecCommand -Command "git merge ${remote}/${resolvedBranch}" @PSBoundParameters | Tee-Object -Variable merge
         if ($merge | Select-String 'Fast-forward' -Quiet) {
-            Invoke-WriteExecCommand -Command "git push ${remote}" @PSBoundParameters
+            Invoke-WriteExecCommand -Command "git push ${remote}${nv}" @PSBoundParameters
         }
     } else {
         Write-Host 'fatal: Remote repository not set.'
@@ -273,7 +285,9 @@ function grbo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
@@ -282,7 +296,9 @@ function grbo {
         $currentBranch = git branch --show-current
         # resolve provided branch
         $resolvedBranch = Get-GitResolvedBranch $Branch
+        $nv = $NoVerify ? ' --no-verify' : ''
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # build list of commands to execute
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git fetch $remote --prune")
@@ -302,7 +318,7 @@ function grbo {
     # check if rebase was successful and push changes
     $behind, $ahead = (git rev-list --count --left-right '@{u}...HEAD') -split "`t"
     if ($? -and $behind -eq 0 -and $ahead -gt 0) {
-        Invoke-WriteExecCommand -Command "git push ${remote}" @PSBoundParameters
+        Invoke-WriteExecCommand -Command "git push ${remote}${nv}" @PSBoundParameters
     }
 }
 function gmb {

--- a/modules/aliases-git/Functions/internal.ps1
+++ b/modules/aliases-git/Functions/internal.ps1
@@ -217,6 +217,10 @@ Command arguments to be passed to the provided command.
 Do not execute the command.
 .PARAMETER Quiet
 Do not print the command string.
+.PARAMETER NoVerify
+Append --no-verify after all arguments to skip git hooks (pre-commit/pre-push).
+Not compatible with a '--' pathspec on commit (git treats trailing args as
+pathspecs); in that rare case pass --no-verify manually before the '--'.
 #>
 function Invoke-WriteExecCommand {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -231,7 +235,9 @@ function Invoke-WriteExecCommand {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     begin {
@@ -242,6 +248,10 @@ function Invoke-WriteExecCommand {
                 $arg = $_ -match '\s|@' ? "'$_'" : $_
                 $sb.Append(" $arg") | Out-Null
             }
+        }
+        # append --no-verify after all arguments (correct position for both push and -m commit)
+        if ($NoVerify) {
+            $sb.Append(' --no-verify') | Out-Null
         }
         # get command string
         $cmnd = $sb.ToString()

--- a/modules/aliases-git/aliases-git.psd1
+++ b/modules/aliases-git/aliases-git.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'aliases-git.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.23.1'
+    ModuleVersion        = '1.24.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -619,8 +619,6 @@ process {
                 # setup profiles
                 Show-LogContext 'setting up profile for all users'
                 wsl.exe --distribution $Distro --user root --exec .assets/provision/setup_profile_allusers.ps1 -UserName $chk.user
-                Show-LogContext 'setting up profile for current user'
-                wsl.exe --distribution $Distro --exec .assets/provision/setup_profile_user.ps1
 
                 # *install PowerShell modules from local modules directory
                 Show-LogContext 'installing ps-modules'
@@ -643,6 +641,10 @@ process {
                 $rms = ($modules.ForEach({ "`$HOME/.local/share/powershell/Modules/$_" })) -join ' '
                 $userCmd = "mkdir -p `$HOME/.local/share/powershell/Modules && rm -rf $rms && cp -rf $srcs `$HOME/.local/share/powershell/Modules/"
                 wsl.exe --distribution $Distro --exec sh -c $userCmd
+                # setup current user profile after modules are installed, so completers
+                # gated on module functions (e.g. Register-MakeCompleter in do-unix) resolve
+                Show-LogContext 'setting up profile for current user'
+                wsl.exe --distribution $Distro --exec .assets/provision/setup_profile_user.ps1
                 # *install PowerShell Az modules
                 if ('az' -in $scopes) {
                     $cmd = [string]::Join("`n",


### PR DESCRIPTION
## Summary

- **Make completer never installed on first provision.** `setup_profile_user.ps1` gates the make-completer block on `Register-MakeCompleter` being importable from `do-unix` at provisioning time, but both orchestrators ran the profile setup *before* the user-scope modules were copied. On a first install the module wasn't on disk yet, so the block was never written (it only appeared on a re-provision). Moved the current-user profile setup to run *after* the module install in both `linux_setup.sh` and `wsl_setup.ps1`. No change to `setup_profile_user.ps1` — the existing gate now resolves correctly, with no shell-startup cost.
- **Az PowerShell modules not installed on the Linux path.** `do-az` (installed on the `az` scope) declares `Az.Accounts`/`Az.ResourceGraph` as `RequiredModules`, but only `wsl_setup.ps1` installed them — a bare-metal/VM/WSL-guest provision via `linux_setup.sh` left `do-az` non-importable. Added the `Az`/`Az.ResourceGraph` install to `linux_setup.sh`, in the final pwsh block after `setup_profile_user.ps1` (so PSGallery is trusted) and after `do-common` (for `Invoke-CommandRetry`), gated on the `az` scope — mirroring `wsl_setup.ps1`.
- **`aliases-git` → `1.24.0` (synced from `ps-modules`).** Adds a `-NoVerify` switch across the git commit/push alias functions to skip pre-commit/pre-push hooks. Synced-module change, reviewed upstream.

## Test plan

- [x] `make lint-diff` — all pre-commit hooks green
- [ ] First-time WSL provision with `pwsh` scope: confirm `#region make completer` is written to `$PROFILE.CurrentUserAllHosts` and `m <tab>` completes Makefile targets
- [ ] Linux (non-WSL) provision with `az` scope: confirm `Import-Module do-az` succeeds (Az.Accounts/Az.ResourceGraph present)
- [ ] Re-provision an already-set-up distro: confirm no duplicate profile blocks (idempotent `Select-String` guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)