### PR TITLE
fix(ps): wsl_install - forward all parameters to wsl_setup

### DIFF
--- a/wsl/wsl_install.ps1
+++ b/wsl/wsl_install.ps1
@@ -9,8 +9,10 @@ The script will perform the following:
 - enable WSL feature on Windows if not yet enabled,
 - install specified WSL distro from available online distros,
 - set up the specified WSL distro with sane defaults,
-- can fix networkin issues on VPN by rewriting DNS settings from selected Windows network interface,
+- can fix networking issues on VPN by rewriting DNS settings from selected Windows network interface,
 - can fix self-signed certificate in chain error, if the host is behind MITM proxy.
+
+All setup related parameters are forwarded to the wsl/wsl_setup.ps1 script.
 
 .PARAMETER Distro
 Name of the WSL distro to install and set up.
@@ -32,6 +34,14 @@ List of installation scopes. Valid values:
 - shell: bat, eza, oh-my-posh, ripgrep, yq, copilot-cli
 - terraform: terraform, terrascan, tflint, tfswitch
 - zsh: zsh shell with plugins
+The shell scope is always installed, regardless of the specified scopes.
+.PARAMETER OmpTheme
+Specify to install oh-my-posh prompt theme engine and name of the theme to be used.
+You can specify one of the three included profiles: base, powerline, nerd,
+or use any theme available on the page: https://ohmyposh.dev/docs/themes/
+.PARAMETER GtkTheme
+Specify gtk theme for wslg. Available values: light, dark.
+Default: automatically detects based on the system theme.
 .PARAMETER Repos
 List of GitHub repositories in format "Owner/RepoName" to clone into the WSL.
 .PARAMETER AddCertificate
@@ -49,6 +59,8 @@ This is useful when the Store download is very slow or unavailable.
 wsl/wsl_install.ps1 -Distro 'Ubuntu'
 # :fix network in the Ubuntu WSL distro
 wsl/wsl_install.ps1 -Distro 'Ubuntu' -FixNetwork
+# :intercept and add certificates in chain
+wsl/wsl_install.ps1 -Distro 'Ubuntu' -AddCertificate
 # :set up WSL distro with specified installation scopes
 $Scope = @('python')
 $Scope = @('az', 'docker')
@@ -56,6 +68,9 @@ $Scope = @('az', 'conda', 'docker', 'gcloud', 'k8s_base')  # with gcloud cli
 $Scope = @('az', 'docker', 'pwsh')
 $Scope = @('az', 'docker', 'k8s_base', 'pwsh', 'terraform')
 wsl/wsl_install.ps1 -Distro 'Ubuntu' -s $Scope
+# :set up shell with the specified oh-my-posh theme
+$OmpTheme = 'nerd'
+wsl/wsl_install.ps1 -Distro 'Ubuntu' -s $Scope -o $OmpTheme
 # :set up WSL distro and clone specified GitHub repositories
 $Repos = @('szymonos/linux-setup-scripts')
 wsl/wsl_install.ps1 -Distro 'Ubuntu' -r $Repos
@@ -76,10 +91,22 @@ param (
     [string]$Distro,
 
     [Alias('s')]
-    [ValidateScript({ $_.ForEach({ $_ -in @('az', 'bun', 'conda', 'distrobox', 'docker', 'gcloud', 'k8s_base', 'k8s_dev', 'k8s_ext', 'nodejs', 'oh_my_posh', 'pwsh', 'python', 'rice', 'shell', 'terraform', 'zsh') }) -notcontains $false })]
+    [ValidateScript(
+        { $_.ForEach({ $_ -in @('az', 'bun', 'conda', 'distrobox', 'docker', 'gcloud', 'k8s_base', 'k8s_dev', 'k8s_ext', 'nodejs', 'oh_my_posh', 'pwsh', 'python', 'rice', 'shell', 'terraform', 'zsh') }) -notcontains $false },
+        ErrorMessage = 'Wrong scope provided. Valid values: az bun conda distrobox docker gcloud k8s_base k8s_dev k8s_ext nodejs oh_my_posh pwsh python rice shell terraform zsh')
+    ]
     [string[]]$Scope,
 
-    [ValidateScript({ $_.ForEach({ $_ -match '^[\w-]+/[\w-]+$' }) -notcontains $false })]
+    [ValidateNotNullOrEmpty()]
+    [string]$OmpTheme = 'base',
+
+    [ValidateSet('light', 'dark')]
+    [string]$GtkTheme,
+
+    [ValidateScript(
+        { $_.ForEach({ $_ -match '^[\w-]+/[\w-]+$' }) -notcontains $false },
+        ErrorMessage = 'Repos should be provided in "Owner/RepoName" format.')
+    ]
     [string[]]$Repos,
 
     [switch]$AddCertificate,
@@ -103,7 +130,7 @@ begin {
     Push-Location "$PSScriptRoot/.."
     # import utils-install for the Update-GitRepository function
     Import-Module (Resolve-Path './modules/utils-install') -Force
-    # import psm-windows for the Update-SessionEnvironmentPath and Join-Str functions
+    # import psm-windows for the Update-SessionEnvironmentPath function
     Import-Module (Resolve-Path './modules/psm-windows') -Force
 
     if (-not $PSBoundParameters.SkipRepoUpdate) {
@@ -118,6 +145,8 @@ begin {
     Update-SessionEnvironmentPath
     # WSL feature name
     $features = @('VirtualMachinePlatform', 'Microsoft-Windows-Subsystem-Linux')
+    # name of the environment variable used to pass parameters to the setup script
+    $paramsEnvVar = 'WSL_SETUP_PARAMS'
 }
 
 process {
@@ -164,24 +193,34 @@ process {
     }
 
     # *Set up WSL
-    # build command string
-    $sb = [System.Text.StringBuilder]::new("wsl/wsl_setup.ps1 -Distro '$Distro'")
-    if ($PSBoundParameters.Scope) {
-        $scopeStr = $Scope | Join-Str -Separator ',' -SingleQuote
-        $sb.Append(" -Scope @($scopeStr,'shell')") | Out-Null
+    # build parameters for the setup script, always including the shell scope
+    # and skipping the repository update, as it has been already done above
+    $setupParams = @{
+        Distro         = $Distro
+        Scope          = [string[]]($Scope + 'shell' | Sort-Object -Unique)
+        OmpTheme       = $OmpTheme
+        SkipRepoUpdate = $true
     }
-    if ($PSBoundParameters.Repos) {
-        $reposStr = $Repos | Join-Str -Separator ',' -SingleQuote
-        $sb.Append(" -Repos @($reposStr)") | Out-Null
+    # forward the specified optional parameters
+    foreach ($param in @('GtkTheme', 'Repos')) {
+        if ($PSBoundParameters.ContainsKey($param)) {
+            $setupParams[$param] = $PSBoundParameters[$param]
+        }
     }
-    if ($PSBoundParameters.AddCertificate) { $sb.Append(' -AddCertificate') | Out-Null }
-    if ($PSBoundParameters.WebDownload) { $sb.Append(' -WebDownload') | Out-Null }
-    $sb.Append(" -OmpTheme 'base'") | Out-Null
-    $sb.Append(' -SkipRepoUpdate') | Out-Null
+    # forward the specified switches as booleans, so they can be splatted after deserialization
+    foreach ($param in @('AddCertificate', 'FixNetwork', 'WebDownload')) {
+        if ($PSBoundParameters[$param]) {
+            $setupParams[$param] = $true
+        }
+    }
+    # pass the parameters as JSON in an environment variable, to splat them in the
+    # child process without building and escaping a command line string
+    [System.Environment]::SetEnvironmentVariable($paramsEnvVar, ($setupParams | ConvertTo-Json -Compress))
     # run the wsl_setup script
-    pwsh.exe -NoProfile -Command $sb.ToString()
+    pwsh.exe -NoProfile -Command "`$setupParams = `$env:$paramsEnvVar | ConvertFrom-Json -AsHashtable; wsl/wsl_setup.ps1 @setupParams"
 }
 
 end {
+    [System.Environment]::SetEnvironmentVariable($paramsEnvVar, $null)
     Pop-Location
 }

--- a/wsl/wsl_setup.ps1
+++ b/wsl/wsl_setup.ps1
@@ -99,7 +99,7 @@ param (
     [Parameter(ParameterSetName = 'GitHub')]
     [ValidateScript(
         { $_.ForEach({ $_ -in @('az', 'bun', 'conda', 'distrobox', 'docker', 'gcloud', 'k8s_base', 'k8s_dev', 'k8s_ext', 'nodejs', 'oh_my_posh', 'pwsh', 'python', 'rice', 'shell', 'terraform', 'zsh') }) -notcontains $false },
-        ErrorMessage = 'Wrong scope provided. Valid values: az conda distrobox docker gcloud k8s_base k8s_dev k8s_ext nodejs pwsh python rice shell terraform zsh')
+        ErrorMessage = 'Wrong scope provided. Valid values: az bun conda distrobox docker gcloud k8s_base k8s_dev k8s_ext nodejs oh_my_posh pwsh python rice shell terraform zsh')
     ]
     [string[]]$Scope,
 


### PR DESCRIPTION
## Problem

`wsl_install.ps1` builds a command string to invoke `wsl_setup.ps1`, and two parameters fall through the cracks:

- `-FixNetwork` is declared and documented but never appended to that command string, so it can never reach `wsl_setup.ps1`.
- `-OmpTheme` and `-GtkTheme` aren't parameters at all — `OmpTheme` is hardcoded to `'base'` and `GtkTheme` has no way in, so `wsl_install.ps1` can't drive most of `wsl_setup.ps1`'s surface.

Separately, `wsl_setup.ps1`'s `Scope` validator `ErrorMessage` lists 15 of the 17 values its own `ValidateScript` accepts — `bun` and `oh_my_posh` are missing — so a rejected scope shows an incomplete list of what's actually allowed.

## Changes

- Replace the `StringBuilder` command-string construction in `wsl_install.ps1` with a parameter hashtable, passed to the child `pwsh` process as JSON in an environment variable and splatted there. No command-line quoting is needed — array values and strings with spaces or embedded quotes survive intact — and adding a forwarded parameter is now a one-line change.
- Add the missing `-OmpTheme` (defaulting to `'base'`, preserving the previous hardcoded value) and `-GtkTheme` parameters, and wire up the existing `-FixNetwork` switch, so `wsl_install.ps1` now accepts every parameter `wsl_setup.ps1` supports, with matching validators and error messages.
- `Scope` keeps no default value, as before — this repo's `wsl_install.ps1` relies entirely on `wsl_setup.ps1`'s own scope auto-detection for sane defaults, unlike a downstream fork that hardcodes one.
- Fix `wsl_setup.ps1`'s `Scope` validator error message to list all 17 accepted values.

`pwsh.exe -File` was evaluated as a simpler alternative and rejected — it silently truncates array arguments:

```text
pwsh -File t.ps1 -Scope az conda docker   ->  Scope count=1: az
pwsh -File t.ps1 -Scope az,conda,docker   ->  Scope count=1: "az,conda,docker"
```

## Verification

`wsl_setup.ps1`'s real param block was extracted into a stub and the actual forwarding code from `wsl_install.ps1` run against it:

| Case | Result |
| --- | --- |
| no `-Scope` given | `Scope = shell` only (no default leaks in), parameter set `Setup` |
| `-Scope @('az','docker') -FixNetwork` | `FixNetwork` now reaches the child process |
| every parameter at once | all 9 bound, parameter set `GitHub` |
| `-Scope @('az','bogus')` | rejected up front by the validator |

Both scripts parse cleanly, and the validator/error-message lists in both files were diffed programmatically and confirmed identical (17 entries each). `make lint` and `make lint-diff` pass, including the repo's bats/Pester suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)